### PR TITLE
moved heightfield up to -0.005 to enable correct collision detection

### DIFF
--- a/leg/myolegs.xml
+++ b/leg/myolegs.xml
@@ -14,12 +14,12 @@
     <compiler angle="radian" meshdir=".." texturedir=".."/>
 
     <asset>
-        <hfield name="terrain" size="7 7 1 1" nrow="100" ncol="100"/>
+        <hfield name="terrain" size="7 7 1 0.001" nrow="100" ncol="100"/>
     </asset>
 
     <worldbody>
 
-        <geom name="terrain" type="hfield" hfield="terrain" pos="0 0 -1" material="matfloor" conaffinity="1" contype="1" rgba="1 1 1 0"/>
+        <geom name="terrain" type="hfield" hfield="terrain" pos="0 0 -0.005" material="matfloor" conaffinity="1" contype="1" rgba="1 1 1 0"/>
         <site name="pelvis_target" size="0.02" pos="0 0 .92" group="4"/>
 
         <body name="root" pos="0 0 1" euler="0 0 -1.57">


### PR DESCRIPTION
This change in conjunction with a later tweak in the myosuite repo will enable correct height field collision detection for `myoLegXXXTerrainWalk-v0` and `myoLegWalk-v0`