### PR TITLE
Added new torso chain for soccer task

### DIFF
--- a/torso/assets/myotorso_chain.xml
+++ b/torso/assets/myotorso_chain.xml
@@ -485,7 +485,7 @@
                 <body name="torso" pos="-0.018 -0.085 0" euler="0 0 -0.33">
                   <inertial pos="0.0046 0.246 0" mass="18.619" diaginertia="0.165 0.15 0.125"/>
                   <body name="head_attach" pos="-0.005 -0.01 0">
-                    <include file="../../myo_sim/head/assets/myohead_rigid_chain.xml"/>
+                    <include file="../../../../simhive/myo_sim/head/assets/myohead_rigid_chain.xml"/>
                   </body>
                   <geom name="torso_geom_1" pos="-0.019 0.121 0" quat="0.980067 0 0 0.198669" type="mesh"  mesh="torso_geom_1_thoracic12_s"/>
                   <geom name="torso_geom_2" pos="-0.032 0.146 0" quat="0.995004 0 0 0.0998334" type="mesh"  mesh="torso_geom_2_thoracic11_s"/>

--- a/torso/assets/myotorso_soccer_chain.xml
+++ b/torso/assets/myotorso_soccer_chain.xml
@@ -485,7 +485,7 @@
                 <body name="torso" pos="-0.018 -0.085 0" euler="0 0 -0.33">
                   <inertial pos="0.0046 0.246 0" mass="18.619" diaginertia="0.165 0.15 0.125"/>
                   <body name="head_attach" pos="-0.005 -0.01 0">
-                    <include file="../../myo_sim/head/assets/myohead_rigid_chain.xml"/>
+                    <include file="../../../../simhive/myo_sim/head/assets/myohead_rigid_chain.xml"/>
                   </body>
                   <geom name="torso_geom_1" pos="-0.019 0.121 0" quat="0.980067 0 0 0.198669" type="mesh"  mesh="torso_geom_1_thoracic12_s"/>
                   <geom name="torso_geom_2" pos="-0.032 0.146 0" quat="0.995004 0 0 0.0998334" type="mesh"  mesh="torso_geom_2_thoracic11_s"/>


### PR DESCRIPTION
A new torso chain file is created for the Myochallenge soccer kick task.
- Reason: Modifying the path for the `head` include breaks the base torso model. Since the relative paths for the includes from the myochallenge folder is different from the base torso model, the current workaround is to have a duplicate file. This will be documented in Issue [62](https://github.com/MyoHub/myo_sim/issues/62)