### PR TITLE
Add sidesite fields for wrapper geoms

### DIFF
--- a/hand/assets/myohand_assets.xml
+++ b/hand/assets/myohand_assets.xml
@@ -326,7 +326,7 @@
       <site site="EDM-P6"/>
       <geom geom="5thmcp_ellipsoid_wrap" sidesite="5thmcp_ellipsoid_site_EDC5_side"/>
       <site site="EDM-P7"/>
-      <geom geom="Fifthpm_wrap"/>
+      <geom geom="Fifthpm_wrap" sidesite="Fifthpm_site_EDC5_side"/>
       <site site="EDM-P8"/>
       <geom geom="Fifthmd_wrap" sidesite="Fifthmd_site_EDC5_side"/>
       <site site="EDM-P9"/>
@@ -358,7 +358,7 @@
       <site site="EPL-P7"/>
       <site site="EPL-P8"/>
       <site site="EPL-P9"/>
-      <geom geom="MPthumb_wrap"/>
+      <geom geom="MPthumb_wrap" sidesite="MPthumb_site_EPL_side"/>
       <site site="EPL-P10"/>
       <site site="EPL-P11"/>
       <geom geom="IPthumb_wrap" sidesite="IPthumb_site_EPL_side"/>
@@ -381,7 +381,7 @@
       <site site="FPL-P3"/>
       <site site="FPL-P4"/>
       <site site="FPL-P5"/>
-      <geom geom="FPL_ellipsoid_wrap"/>
+      <geom geom="FPL_ellipsoid_wrap" sidesite="FPL_ellipsoid_site_FPL_side"/>
       <site site="FPL-P7"/>
       <site site="FPL-P8"/>
       <geom geom="MPthumb_wrap" sidesite="MPthumb_site_FPL_side"/>


### PR DESCRIPTION
Fix a bug that reduces the actuator count when loading the `myohand_die` model with the latest mujoco.

- **Discussion thread:** [https://github.com/MyoHub/mjlab_myosuite/pull/4#discussion_r2721064619](https://github.com/MyoHub/mjlab_myosuite/pull/4#discussion_r2721064619)
- **Issue report:** [https://github.com/ttktjmt/mjlab_myosuite/blob/aeabb6016ef6e1db8cbd412c5135c4da996e0d60/ISSUE_REPORT.md](https://github.com/ttktjmt/mjlab_myosuite/blob/aeabb6016ef6e1db8cbd412c5135c4da996e0d60/ISSUE_REPORT.md)
- **Temporary fixes:** [https://github.com/ttktjmt/mjlab_myosuite/tree/die-reorientation/src/mjlab_myosuite/robot/assets](https://github.com/ttktjmt/mjlab_myosuite/tree/die-reorientation/src/mjlab_myosuite/robot/assets)
