### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.11"
+
+      - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Check formatting with ruff
+        run: uv run ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies for MuJoCo rendering
+        run: sudo apt-get install -y libgl1-mesa-glx libglib2.0-0
+
+      - name: Install package
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py --ignore=tests/test_bimanual_muscle_symmetry.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, mm_refactor_mjspec]
   pull_request:
-    branches: [main]
+    branches: [main, mm_refactor_mjspec]
 
 jobs:
   lint:
@@ -16,6 +16,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: uv sync --dev
 
       - name: Lint with ruff
         run: uv run ruff check .


### PR DESCRIPTION
This adds `.github/workflows/ci.yml` with two jobs that run on every push and pull request targeting main.

The `lint` job runs `ruff check` and `ruff format --check` using Python 3.11 and uv via `astral-sh/setup-uv@v4`. It is designed to complete well under 60 seconds.

The `test` job depends on `lint` passing. It installs the MuJoCo headless rendering system libraries (`libgl1-mesa-glx`, `libglib2.0-0`), syncs the dev environment with `uv sync --dev`, then runs the test suite with `pytest -x -n auto -q` for fast parallel feedback.

Two test files are intentionally excluded from CI: `test_equivalence.py` and `test_bimanual_muscle_symmetry.py`. Both import `musclemimic_models`, a private package not available in the public CI environment. All other tests under `tests/` only depend on `mujoco`, `numpy`, `matplotlib`, `scipy`, and `myo_sim` itself, all of which are declared in `pyproject.toml`.

`pytest-xdist` (needed for `-n auto`) was already present in the dev dependency group.