### PR TITLE
Fix code review issues: testpaths, lazy parametrize, unified registry, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,14 +56,14 @@ All meshes live in `myo_sim/models/meshes/` and are shared across models. `scene
 
 ## Design Principles (issue #75)
 
-The target architecture separates concerns into four layers:
+The architecture separates concerns into four layers, implemented through file-naming conventions within `myo_sim/models/<part>/assets/` and the `myo_sim/build/` package:
 
-1. **Kinematics** (`kinematics/`) — immutable skeleton: bodies, joints, and global structural sites. Defined once; never duplicated across parts.
-2. **Parts** (`parts/`) — body-part-local actuation: muscles, tendons, wrapping surfaces, equality constraints, and local via/wrapping sites.
-3. **Interfaces** (`interfaces/`) — explicit cross-part attachment and muscle-ownership declarations.
-4. **Build** (`build/`) — deterministic composition pipeline that assembles kinematics + parts into full models.
+1. **Kinematics** (`*_chain.xml`) — immutable skeleton: bodies, joints, and global structural sites. Defined once per body part; never duplicated across assemblies.
+2. **Actuation** (`*_muscle.xml`, `*_tendon.xml`) — body-part-local actuation: muscles, tendons, wrapping surfaces, equality constraints, and local via/wrapping sites.
+3. **Assets** (`*_assets.xml`) — mesh, material, and texture declarations shared within a body part.
+4. **Build** (`myo_sim/build/compose.py`) — deterministic composition pipeline that assembles chains, actuation, and contacts into full models using MjSpec.
 
-When adding or editing model elements, respect this separation: structural geometry belongs in kinematics, actuation belongs in parts, and cross-part dependencies must be declared in interfaces.
+When adding or editing model elements, respect this separation: structural geometry belongs in chain files, actuation belongs in muscle/tendon files, and cross-part composition is handled in `myo_sim/build/`.
 
 ## Naming Conventions
 

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -28,10 +28,8 @@ for _name, _rel, _ver in _FRAGMENT_CATALOG:
     if _p.exists():
         FragmentRegistry._store[_name] = FragmentInfo(name=_name, path=_p, version=_ver)
 
-REGISTRY = {
-    "myolegs": "leg/myolegs.xml",
-    "myotorso": "torso/myotorso.xml",
-}
+# Derived from _FRAGMENT_CATALOG so adding a model requires editing one place.
+REGISTRY = {name: rel for name, rel, _ in _FRAGMENT_CATALOG}
 
 
 def get_xml_path(name: str) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ myo_sim = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = [".", "tests"]
-python_files = ["test_sims.py", "test_*.py"]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
 
 [tool.ruff]
 line-length = 128

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -288,10 +288,23 @@ def _shared_actuator_names() -> list[str]:
     return shared
 
 
-_SHARED_MUSCLES = _shared_actuator_names()
-_SHARED_MUSCLES_BY_REGION = {
-    region: [name for name in _SHARED_MUSCLES if _actuator_region(name) == region] for region in _REGIONS
-}
+def _get_shared_muscles_by_region() -> dict[str, list[str]]:
+    """Compute shared muscles by region, called lazily during test generation."""
+    shared = _shared_actuator_names()
+    return {region: [name for name in shared if _actuator_region(name) == region] for region in _REGIONS}
+
+
+def pytest_generate_tests(metafunc):
+    """Lazily parametrize equivalence tests from the shared muscle list."""
+    region_map = {
+        "test_arm_muscle_equivalence": "arms",
+        "test_leg_muscle_equivalence": "legs",
+        "test_torso_muscle_equivalence": "torso",
+    }
+    if metafunc.function.__name__ in region_map and "ref_act_name" in metafunc.fixturenames:
+        region = region_map[metafunc.function.__name__]
+        by_region = _get_shared_muscles_by_region()
+        metafunc.parametrize("ref_act_name", by_region[region])
 
 
 # ---------------------------------------------------------------------------
@@ -421,17 +434,14 @@ def _check_muscle_equivalence(
     assert not failures, f"{ref_act_name}: {len(failures)} joint(s) failed:\n" + "\n".join(failures)
 
 
-@pytest.mark.parametrize("ref_act_name", _SHARED_MUSCLES_BY_REGION["arms"])
 def test_arm_muscle_equivalence(ref_act_name, ref_model, tgt_model, ref_eq_map, tgt_eq_map):
     _check_muscle_equivalence(ref_act_name, "arms", ref_model, tgt_model, ref_eq_map, tgt_eq_map)
 
 
-@pytest.mark.parametrize("ref_act_name", _SHARED_MUSCLES_BY_REGION["legs"])
 def test_leg_muscle_equivalence(ref_act_name, ref_model, tgt_model, ref_eq_map, tgt_eq_map):
     _check_muscle_equivalence(ref_act_name, "legs", ref_model, tgt_model, ref_eq_map, tgt_eq_map)
 
 
-@pytest.mark.parametrize("ref_act_name", _SHARED_MUSCLES_BY_REGION["torso"])
 def test_torso_muscle_equivalence(ref_act_name, ref_model, tgt_model, ref_eq_map, tgt_eq_map):
     _check_muscle_equivalence(ref_act_name, "torso", ref_model, tgt_model, ref_eq_map, tgt_eq_map)
 


### PR DESCRIPTION
This PR addresses four issues identified in a code review of the mm_refactor_mjspec branch.

pyproject.toml testpaths was [".", "tests"], but test_sims.py has moved into tests/ so scanning "." is redundant and causes double-discovery. Now just ["tests"], and the redundant "test_sims.py" entry in python_files is removed.

test_equivalence.py called build_model("myofullbody") at module level via _SHARED_MUSCLES = _shared_actuator_names(), which made every pytest invocation pay the full-body model build cost at collection time even for unrelated tests. The module-level variables are replaced with a pytest_generate_tests hook that computes the shared muscle list only when the equivalence test functions are actually being collected. The @pytest.mark.parametrize decorators are removed since the hook handles parametrization.

myo_sim/__init__.py had two parallel model inventories (_FRAGMENT_CATALOG and REGISTRY) covering overlapping models declared twice. REGISTRY is now derived from _FRAGMENT_CATALOG with a one-liner, so adding a model requires editing only one place.

CLAUDE.md described kinematics/, parts/, and interfaces/ directories that do not exist. The design principles section is rewritten to describe the actual file-naming conventions used within myo_sim/models/<part>/assets/ and the role of myo_sim/build/compose.py.

All 29 passing tests continue to pass (uv run pytest tests/ -x --ignore=tests/test_equivalence.py).