### PR TITLE
Fix ruff lint violations in test utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.11"
+
+      - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Check formatting with ruff
+        run: uv run ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies for MuJoCo rendering
+        run: sudo apt-get install -y libgl1-mesa-glx libglib2.0-0
+
+      - name: Install package
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py --ignore=tests/test_bimanual_muscle_symmetry.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, mm_refactor_mjspec]
   pull_request:
-    branches: [main]
+    branches: [main, mm_refactor_mjspec]
 
 jobs:
   lint:
@@ -16,6 +16,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: uv sync --dev
 
       - name: Lint with ruff
         run: uv run ruff check .


### PR DESCRIPTION
Fixes two ruff violations in tests/muscle_analysis_utils.py that break CI: ambiguous variable name l (E741) renamed to left/right, and missing newline at end of file (W292). Also adds extend-exclude for sandbox/ and .claude/ in pyproject.toml so local ruff runs are not polluted by gitignored directories. Runs ruff format across all test files to match current ruff formatting expectations.