### PR TITLE
Fix ruff violations in muscle_analysis_utils.py (E741, W292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install system dependencies for MuJoCo rendering
-        run: sudo apt-get install -y libgl1-mesa-glx libglib2.0-0
+      - name: Install system dependencies for MuJoCo
+        run: sudo apt-get install -y libgl1 libglib2.0-0 libosmesa6
 
       - name: Install package
         run: uv sync --dev

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -156,10 +156,7 @@ MODEL_REGISTRY = {
 def pair_is_supported(pair, include_left_arm_contacts: bool):
     if include_left_arm_contacts:
         return True
-    return not (
-        pair.get("geom1", "").endswith("_l")
-        or pair.get("geom2", "").endswith("_l")
-    )
+    return not (pair.get("geom1", "").endswith("_l") or pair.get("geom2", "").endswith("_l"))
 
 
 def load_torso_spec(registration: ModelRegistration):
@@ -176,9 +173,7 @@ def load_torso_spec(registration: ModelRegistration):
     add_contact_pairs(
         torso,
         ARM_CONTACTS_XML,
-        include_pair=lambda pair: pair_is_supported(
-            pair, registration.include_left_arm_contacts
-        ),
+        include_pair=lambda pair: pair_is_supported(pair, registration.include_left_arm_contacts),
     )
     if registration.include_legs:
         add_contact_pairs(torso, LEG_CONTACTS_XML)
@@ -329,10 +324,7 @@ def load_left_arm_spec(registration: ModelRegistration):
         return load_mirrored_left_arm_spec(registration.mirror_rules)
     if registration.left_arm_strategy == LEFT_ARM_STRATEGY_NONE:
         return None
-    raise ValueError(
-        f"Unknown left arm strategy for {registration.name}: "
-        f"{registration.left_arm_strategy}"
-    )
+    raise ValueError(f"Unknown left arm strategy for {registration.name}: {registration.left_arm_strategy}")
 
 
 def build_torso_arms_model(registration: ModelRegistration):
@@ -392,9 +384,7 @@ def build_model(model_name: str):
         registration = MODEL_REGISTRY[model_name]
     except KeyError as exc:
         available = ", ".join(sorted(MODEL_REGISTRY))
-        raise ValueError(
-            f"Unknown model selection: {model_name}. Available: {available}"
-        ) from exc
+        raise ValueError(f"Unknown model selection: {model_name}. Available: {available}") from exc
     return build_registered_model(registration)
 
 
@@ -408,8 +398,7 @@ def view_model(model):
         if sys.platform == "darwin" and "mjpython" in str(exc):
             script = Path(__file__).name
             raise SystemExit(
-                "MuJoCo passive viewer requires mjpython on macOS.\n"
-                f"Run: mjpython -m myo_sim.build.{Path(script).stem} --view"
+                f"MuJoCo passive viewer requires mjpython on macOS.\nRun: mjpython -m myo_sim.build.{Path(script).stem} --view"
             ) from exc
         raise
 
@@ -433,10 +422,7 @@ def main():
 
     model = build_model(args.model)
     registration = MODEL_REGISTRY[args.model]
-    print(
-        f"compiled {args.model}: "
-        f"nbody={model.nbody}, njnt={model.njnt}, nu={model.nu}"
-    )
+    print(f"compiled {args.model}: nbody={model.nbody}, njnt={model.njnt}, nu={model.nu}")
     print(f"description: {registration.description}")
 
     if args.view:

--- a/myo_sim/build/hand.py
+++ b/myo_sim/build/hand.py
@@ -101,20 +101,14 @@ def prune_arm_spec_to_hand(spec, side: str):
     removed_joints = {side_name(name, side) for name in RIGHT_HAND_REMOVED_JOINTS}
 
     for equality in list(spec.equalities):
-        if (
-            equality.name1 in removed_joints
-            or equality.name2 in removed_joints
-        ):
+        if equality.name1 in removed_joints or equality.name2 in removed_joints:
             spec.delete(equality)
 
     for actuator in list(spec.actuators):
         if base_actuator_name(actuator.name, side) not in RIGHT_HAND_ACTUATORS:
             spec.delete(actuator)
 
-    tendon_name_map = {
-        actuator.target: add_side_suffix(actuator.target, side)
-        for actuator in spec.actuators
-    }
+    tendon_name_map = {actuator.target: add_side_suffix(actuator.target, side) for actuator in spec.actuators}
     for tendon in list(spec.tendons):
         if tendon.name not in tendon_name_map:
             spec.delete(tendon)

--- a/myo_sim/build/utils.py
+++ b/myo_sim/build/utils.py
@@ -110,11 +110,7 @@ def add_contact_pairs(spec, contacts_xml: Path, include_pair=None):
             geomname2=pair.get("geom2"),
             condim=int(pair.get("condim")) if pair.get("condim") else None,
             solref=float_list(pair.get("solref")) if pair.get("solref") else None,
-            solreffriction=(
-                float_list(pair.get("solreffriction"))
-                if pair.get("solreffriction")
-                else None
-            ),
+            solreffriction=(float_list(pair.get("solreffriction")) if pair.get("solreffriction") else None),
             solimp=float_list(pair.get("solimp")) if pair.get("solimp") else None,
             margin=float(pair.get("margin")) if pair.get("margin") else None,
             gap=float(pair.get("gap")) if pair.get("gap") else None,
@@ -130,7 +126,7 @@ def mirror_name(value: str, rules: MirrorRules):
             return value.replace(old, new)
     for old, new in rules.prefix_replacements:
         if value.startswith(old):
-            return f"{new}{value[len(old):]}"
+            return f"{new}{value[len(old) :]}"
     if value == "MatSkin":
         return rules.mirrored_material
     if value.endswith("_r"):
@@ -148,9 +144,7 @@ def should_mirror_class_name(value: str, rules: MirrorRules):
 
 def mirror_reference(element, attr_name: str, attr_value: str, rules: MirrorRules):
     mirrored = mirror_name(attr_value, rules)
-    should_lowercase_geom = (attr_name == "name" and element.tag == "geom") or (
-        attr_name == "geom"
-    )
+    should_lowercase_geom = (attr_name == "name" and element.tag == "geom") or (attr_name == "geom")
     if should_lowercase_geom:
         for prefix in rules.lowercase_geom_prefixes:
             if mirrored.startswith(prefix):
@@ -163,11 +157,7 @@ def mirror_xyz_attribute(element, attr_name: str, rules: MirrorRules):
     if len(values) != 3:
         return
     element_name = element.get("name")
-    if (
-        element.tag == "body"
-        and element_name in rules.body_pos_x_mirror_names
-        and attr_name == "pos"
-    ):
+    if element.tag == "body" and element_name in rules.body_pos_x_mirror_names and attr_name == "pos":
         values[0] *= -1
     else:
         values[2] *= -1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ python_files = ["test_sims.py", "test_*.py"]
 
 [tool.ruff]
 line-length = 128
+extend-exclude = ["sandbox", ".claude"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]

--- a/tests/debug_muscle_bimanual.py
+++ b/tests/debug_muscle_bimanual.py
@@ -59,12 +59,8 @@ def analyze_pair(model, data, eq_map, base_muscle: str, base_joint: str, *, plot
         muscle = base_muscle + MUSCLE_SUFFIX[side]
         joint = base_joint + JOINT_SUFFIX[side]
 
-        act_id = mujoco.mj_name2id(
-            model, mujoco.mjtObj.mjOBJ_ACTUATOR, muscle
-        )
-        jnt_id = mujoco.mj_name2id(
-            model, mujoco.mjtObj.mjOBJ_JOINT, joint
-        )
+        act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, muscle)
+        jnt_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, joint)
 
         if act_id < 0 or jnt_id < 0:
             return None
@@ -73,15 +69,11 @@ def analyze_pair(model, data, eq_map, base_muscle: str, base_joint: str, *, plot
         if tendon_id < 0:
             return None
 
-        jnt_range, ma = compute_moment_arm_curve(
-            model, data, tendon_id, jnt_id, eps=EPS, eq_map=eq_map
-        )
+        jnt_range, ma = compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=EPS, eq_map=eq_map)
         if jnt_range is None or np.allclose(ma, 0, atol=5e-5):
             return None
 
-        mtu_len, forces = compute_force_length_curve(
-            model, data, act_id, jnt_id, activation=ACTIVATION, eq_map=eq_map
-        )
+        mtu_len, forces = compute_force_length_curve(model, data, act_id, jnt_id, activation=ACTIVATION, eq_map=eq_map)
 
         curves[side] = dict(
             muscle=muscle,
@@ -155,9 +147,7 @@ def run_all(model, data, eq_map, *, plot=False):
             if q0 == q1:
                 continue
 
-            jnt_range, ma = compute_moment_arm_curve(
-                model, data, tendon_id, jnt_id, eps=EPS, eq_map=eq_map
-            )
+            jnt_range, ma = compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=EPS, eq_map=eq_map)
             if jnt_range is None or np.allclose(ma, 0, atol=5e-5):
                 continue
 

--- a/tests/debug_muscle_leg.py
+++ b/tests/debug_muscle_leg.py
@@ -52,15 +52,11 @@ def analyze_pair(base_muscle: str, base_joint: str):
         if tendon_id < 0:
             return None
 
-        jnt_range, ma = compute_moment_arm_curve(
-            model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP
-        )
+        jnt_range, ma = compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP)
         if jnt_range is None or ma is None or np.allclose(ma, 0, atol=1e-6):
             return None
 
-        mtu_len, forces = compute_force_length_curve(
-            model, data, act_id, jnt_id, activation=ACTIVATION, eq_map=EQ_MAP
-        )
+        mtu_len, forces = compute_force_length_curve(model, data, act_id, jnt_id, activation=ACTIVATION, eq_map=EQ_MAP)
 
         curves[side] = dict(
             muscle=muscle,
@@ -71,9 +67,7 @@ def analyze_pair(base_muscle: str, base_joint: str):
         )
 
     out_path = OUT_DIR / f"{base_muscle}_{base_joint}.png"
-    return plot_pair(
-        curves, title=f"{base_muscle} @ {base_joint}", out_path=out_path
-    )
+    return plot_pair(curves, title=f"{base_muscle} @ {base_joint}", out_path=out_path)
 
 
 print("\nRunning LEG muscle symmetry analysis...\n", flush=True)
@@ -85,9 +79,7 @@ total = 0
 
 
 for act_id in range(model.nu):
-    muscle_name = mujoco.mj_id2name(
-        model, mujoco.mjtObj.mjOBJ_ACTUATOR, act_id
-    )
+    muscle_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, act_id)
     if muscle_name is None or not muscle_name.endswith("_r"):
         continue
 
@@ -97,9 +89,7 @@ for act_id in range(model.nu):
         continue
 
     for jnt_id in range(model.njnt):
-        jnt_name = mujoco.mj_id2name(
-            model, mujoco.mjtObj.mjOBJ_JOINT, jnt_id
-        )
+        jnt_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, jnt_id)
         if jnt_name is None:
             continue
 
@@ -107,9 +97,7 @@ for act_id in range(model.nu):
         if q0 == q1:
             continue
 
-        jnt_range, ma = compute_moment_arm_curve(
-            model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP
-        )
+        jnt_range, ma = compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP)
         if jnt_range is None or np.allclose(ma, 0, atol=1e-6):
             continue
 

--- a/tests/debug_muscle_torso.py
+++ b/tests/debug_muscle_torso.py
@@ -33,19 +33,27 @@ ACTIVATION = 1.0
 
 # Joints that are inherently non-symmetric (lateral bending, axial rotation)
 SKIP_JOINTS = {
-    "lat_bending", "axial_rotation",
-    "L4_L5_LB", "L4_L5_AR", "Abs_t1",
-    "L3_L4_LB", "L3_L4_AR", "Abs_t2",
-    "L2_L3_LB", "L2_L3_AR", "Abs_r3",
-    "L1_L2_LB", "L1_L2_AR",
+    "lat_bending",
+    "axial_rotation",
+    "L4_L5_LB",
+    "L4_L5_AR",
+    "Abs_t1",
+    "L3_L4_LB",
+    "L3_L4_AR",
+    "Abs_t2",
+    "L2_L3_LB",
+    "L2_L3_AR",
+    "Abs_r3",
+    "L1_L2_LB",
+    "L1_L2_AR",
 }
 
 
 def comment_out_lines(src: Path, dst: Path, start: int, end: int):
     """Comment out lines [start, end] in src and write to dst."""
     lines = src.read_text().splitlines(True)
-    chunk = "".join(lines[start - 1:end])
-    lines[start - 1:end] = [f"<!--\n{chunk}-->\n"]
+    chunk = "".join(lines[start - 1 : end])
+    lines[start - 1 : end] = [f"<!--\n{chunk}-->\n"]
     dst.parent.mkdir(parents=True, exist_ok=True)
     dst.write_text("".join(lines))
 
@@ -88,15 +96,11 @@ def analyze_pair(base_muscle: str, base_joint: str):
         if tendon_id < 0:
             continue
 
-        jnt_range, ma = compute_moment_arm_curve(
-            model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP
-        )
+        jnt_range, ma = compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP)
         if jnt_range is None or ma is None or np.allclose(ma, 0, atol=1e-6):
             return None
 
-        mtu_len, forces = compute_force_length_curve(
-            model, data, act_id, jnt_id, activation=ACTIVATION, eq_map=EQ_MAP
-        )
+        mtu_len, forces = compute_force_length_curve(model, data, act_id, jnt_id, activation=ACTIVATION, eq_map=EQ_MAP)
 
         curves[side] = dict(
             muscle=muscle,
@@ -110,9 +114,7 @@ def analyze_pair(base_muscle: str, base_joint: str):
         return None
 
     out_path = OUT_DIR / f"{base_muscle}_{base_joint}.png"
-    return plot_pair(
-        curves, title=f"{base_muscle} @ {base_joint}", out_path=out_path
-    )
+    return plot_pair(curves, title=f"{base_muscle} @ {base_joint}", out_path=out_path)
 
 
 print("\nRunning TORSO muscle symmetry analysis...\n", flush=True)
@@ -123,9 +125,7 @@ skip_cnt = 0
 total = 0
 
 for act_id in range(model.nu):
-    base_muscle = mujoco.mj_id2name(
-        model, mujoco.mjtObj.mjOBJ_ACTUATOR, act_id
-    )
+    base_muscle = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, act_id)
     if base_muscle is None:
         continue
 
@@ -134,9 +134,7 @@ for act_id in range(model.nu):
         continue
 
     for jnt_id in range(model.njnt):
-        jnt_name = mujoco.mj_id2name(
-            model, mujoco.mjtObj.mjOBJ_JOINT, jnt_id
-        )
+        jnt_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, jnt_id)
         if jnt_name is None or jnt_name in SKIP_JOINTS:
             continue
 
@@ -144,9 +142,7 @@ for act_id in range(model.nu):
         if q0 == q1:
             continue
 
-        jnt_range, ma = compute_moment_arm_curve(
-            model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP
-        )
+        jnt_range, ma = compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=EPS, eq_map=EQ_MAP)
         if jnt_range is None or np.allclose(ma, 0, atol=1e-6):
             continue
 

--- a/tests/muscle_analysis_utils.py
+++ b/tests/muscle_analysis_utils.py
@@ -24,12 +24,8 @@ def parse_joint_equalities(expanded_xml_path, model):
         if slave_name is None or master_name is None:
             continue
 
-        slave_id = mujoco.mj_name2id(
-            model, mujoco.mjtObj.mjOBJ_JOINT, slave_name
-        )
-        master_id = mujoco.mj_name2id(
-            model, mujoco.mjtObj.mjOBJ_JOINT, master_name
-        )
+        slave_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, slave_name)
+        master_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, master_name)
         if slave_id < 0 or master_id < 0:
             continue
 
@@ -77,14 +73,12 @@ def apply_eq_constraints(data, model, eq_map):
 
         slave_value = 0.0
         for power, coeff in enumerate(coeffs):
-            slave_value += coeff * (master_value ** power)
+            slave_value += coeff * (master_value**power)
 
         data.qpos[slave_q] = slave_value
 
 
-def compute_moment_arm_curve(
-    model, data, tendon_id, jnt_id, eps=1e-5, n=100, eq_map=None
-):
+def compute_moment_arm_curve(model, data, tendon_id, jnt_id, eps=1e-5, n=100, eq_map=None):
     """Compute moment arm curve for a tendon across a joint's range using finite differences."""
     qpos_id = model.jnt_qposadr[jnt_id]
     q0, q1 = model.jnt_range[jnt_id]
@@ -112,9 +106,7 @@ def compute_moment_arm_curve(
     return qs, ma
 
 
-def compute_force_length_curve(
-    model, data, act_id, jnt_id, activation=1.0, n=100, eq_map=None
-):
+def compute_force_length_curve(model, data, act_id, jnt_id, activation=1.0, n=100, eq_map=None):
     """Compute MTU force-length curve for an actuator across a joint's range."""
     qpos_id = model.jnt_qposadr[jnt_id]
     q0, q1 = model.jnt_range[jnt_id]
@@ -147,27 +139,21 @@ def pair_discrepancy_summary(
     force_atol=0.1,
 ):
     """Compare left/right curves and return pass/fail flags plus max discrepancies."""
-    r, l = curves["right"], curves["left"]
+    right, left = curves["right"], curves["left"]
 
-    moment_arm_diff = np.abs(r["moment_arms"] - l["moment_arms"])
+    moment_arm_diff = np.abs(right["moment_arms"] - left["moment_arms"])
     moment_arm_ok = np.allclose(
-        r["moment_arms"],
-        l["moment_arms"],
+        right["moment_arms"],
+        left["moment_arms"],
         atol=moment_arm_tol,
         rtol=moment_arm_rtol,
     )
 
-    force_diff = np.abs(r["forces"] - l["forces"])
-    force_scale = np.maximum(np.abs(r["forces"]), np.abs(l["forces"]))
-    force_ok = np.all(
-        (force_diff < force_atol) | (force_diff < force_rtol * force_scale)
-    )
+    force_diff = np.abs(right["forces"] - left["forces"])
+    force_scale = np.maximum(np.abs(right["forces"]), np.abs(left["forces"]))
+    force_ok = np.all((force_diff < force_atol) | (force_diff < force_rtol * force_scale))
     nonzero_force = force_scale > 0.0
-    force_pct = (
-        float(np.max(force_diff[nonzero_force] / force_scale[nonzero_force]) * 100.0)
-        if np.any(nonzero_force)
-        else 0.0
-    )
+    force_pct = float(np.max(force_diff[nonzero_force] / force_scale[nonzero_force]) * 100.0) if np.any(nonzero_force) else 0.0
 
     return {
         "ok": bool(moment_arm_ok and force_ok),

--- a/tests/test_bimanual_muscle_symmetry.py
+++ b/tests/test_bimanual_muscle_symmetry.py
@@ -46,4 +46,3 @@ def test_discovered_bimanual_muscle_pairs_have_symmetric_curves(
             failures.append((pair.label, summary))
 
     assert not failures
-

--- a/tests/test_build_registry.py
+++ b/tests/test_build_registry.py
@@ -23,7 +23,4 @@ def test_every_registered_model_has_build_strategy():
         "myolegs_abdomen": BuildStrategy.LEGS_ABDOMEN,
     }
 
-    assert {
-        name: registration.build_strategy
-        for name, registration in MODEL_REGISTRY.items()
-    } == expected
+    assert {name: registration.build_strategy for name, registration in MODEL_REGISTRY.items()} == expected

--- a/tests/test_chest_ownership.py
+++ b/tests/test_chest_ownership.py
@@ -12,11 +12,7 @@ def body_id(model, name: str) -> int:
 
 
 def xml_body_names(path):
-    return {
-        body.get("name")
-        for body in ET.parse(path).getroot().iter("body")
-        if body.get("name")
-    }
+    return {body.get("name") for body in ET.parse(path).getroot().iter("body") if body.get("name")}
 
 
 def test_chest_scaffold_is_torso_owned_not_arm_owned():

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -44,6 +44,7 @@ CURVE_POINTS = 100
 # musclemimic uses _left suffix for left arm muscles; myo_sim uses _l
 # ---------------------------------------------------------------------------
 
+
 def _ref_to_tgt_actuator(name: str) -> str:
     if name.endswith("_left"):
         return name[: -len("_left")] + "_l"
@@ -248,6 +249,7 @@ def _joint_region(ref_jnt_name: str) -> str | None:
 # Module-scoped fixtures: load models once per test session
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="module")
 def ref_model():
     return mujoco.MjModel.from_xml_path(str(REF_XML))
@@ -272,14 +274,12 @@ def tgt_eq_map(tgt_model):
 # Shared actuator list — cheap to build, just name lookups
 # ---------------------------------------------------------------------------
 
+
 def _shared_actuator_names() -> list[str]:
     """Return ref-side actuator names whose tgt mapping also exists."""
     ref = mujoco.MjModel.from_xml_path(str(REF_XML))
     tgt = build_model(TGT_MODEL_NAME)
-    tgt_names = {
-        mujoco.mj_id2name(tgt, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
-        for i in range(tgt.nu)
-    }
+    tgt_names = {mujoco.mj_id2name(tgt, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(tgt.nu)}
     shared = []
     for i in range(ref.nu):
         ref_name = mujoco.mj_id2name(ref, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
@@ -290,14 +290,14 @@ def _shared_actuator_names() -> list[str]:
 
 _SHARED_MUSCLES = _shared_actuator_names()
 _SHARED_MUSCLES_BY_REGION = {
-    region: [name for name in _SHARED_MUSCLES if _actuator_region(name) == region]
-    for region in _REGIONS
+    region: [name for name in _SHARED_MUSCLES if _actuator_region(name) == region] for region in _REGIONS
 }
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 def _check_muscle_equivalence(
     ref_act_name,
@@ -318,10 +318,7 @@ def _check_muscle_equivalence(
     ref_tendon_id = ref_model.actuator_trnid[ref_act_id, 0]
     tgt_tendon_id = tgt_model.actuator_trnid[tgt_act_id, 0]
 
-    tgt_joint_names = {
-        mujoco.mj_id2name(tgt_model, mujoco.mjtObj.mjOBJ_JOINT, i)
-        for i in range(tgt_model.njnt)
-    }
+    tgt_joint_names = {mujoco.mj_id2name(tgt_model, mujoco.mjtObj.mjOBJ_JOINT, i) for i in range(tgt_model.njnt)}
 
     joints_checked = 0
     failures = []
@@ -421,30 +418,22 @@ def _check_muscle_equivalence(
     if joints_checked == 0:
         pytest.skip("no joints with non-zero moment arm found")
 
-    assert not failures, (
-        f"{ref_act_name}: {len(failures)} joint(s) failed:\n" + "\n".join(failures)
-    )
+    assert not failures, f"{ref_act_name}: {len(failures)} joint(s) failed:\n" + "\n".join(failures)
 
 
 @pytest.mark.parametrize("ref_act_name", _SHARED_MUSCLES_BY_REGION["arms"])
 def test_arm_muscle_equivalence(ref_act_name, ref_model, tgt_model, ref_eq_map, tgt_eq_map):
-    _check_muscle_equivalence(
-        ref_act_name, "arms", ref_model, tgt_model, ref_eq_map, tgt_eq_map
-    )
+    _check_muscle_equivalence(ref_act_name, "arms", ref_model, tgt_model, ref_eq_map, tgt_eq_map)
 
 
 @pytest.mark.parametrize("ref_act_name", _SHARED_MUSCLES_BY_REGION["legs"])
 def test_leg_muscle_equivalence(ref_act_name, ref_model, tgt_model, ref_eq_map, tgt_eq_map):
-    _check_muscle_equivalence(
-        ref_act_name, "legs", ref_model, tgt_model, ref_eq_map, tgt_eq_map
-    )
+    _check_muscle_equivalence(ref_act_name, "legs", ref_model, tgt_model, ref_eq_map, tgt_eq_map)
 
 
 @pytest.mark.parametrize("ref_act_name", _SHARED_MUSCLES_BY_REGION["torso"])
 def test_torso_muscle_equivalence(ref_act_name, ref_model, tgt_model, ref_eq_map, tgt_eq_map):
-    _check_muscle_equivalence(
-        ref_act_name, "torso", ref_model, tgt_model, ref_eq_map, tgt_eq_map
-    )
+    _check_muscle_equivalence(ref_act_name, "torso", ref_model, tgt_model, ref_eq_map, tgt_eq_map)
 
 
 def test_actuator_coverage():

--- a/tests/test_fragment_registry.py
+++ b/tests/test_fragment_registry.py
@@ -40,4 +40,3 @@ def test_fragment_info_attributes():
     assert isinstance(info.path, __import__("pathlib").Path)
     assert isinstance(info.version, int)
     assert info.name == "myolegs"
-

--- a/tests/test_leg_muscle_symmetry.py
+++ b/tests/test_leg_muscle_symmetry.py
@@ -49,4 +49,3 @@ def test_discovered_leg_muscle_pairs_have_symmetric_curves(leg_model_context, di
 
     assert checked_pairs
     assert not failures
-

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -69,7 +69,7 @@ class TestMuscleMimicFullBody(unittest.TestCase):
         self.assertEqual(
             m.njnt,
             MUSCLEMIMIC_FULLBODY_SPEC["njnt"],
-            f"myofullbody.xml has {m.njnt} joints, expected {MUSCLEMIMIC_FULLBODY_SPEC['njnt']} " f"(musclemimic spec)",
+            f"myofullbody.xml has {m.njnt} joints, expected {MUSCLEMIMIC_FULLBODY_SPEC['njnt']} (musclemimic spec)",
         )
 
     def test_myofullbody_actuators(self):
@@ -77,7 +77,7 @@ class TestMuscleMimicFullBody(unittest.TestCase):
         self.assertEqual(
             m.nu,
             MUSCLEMIMIC_FULLBODY_SPEC["nu"],
-            f"myofullbody.xml has {m.nu} actuators, expected {MUSCLEMIMIC_FULLBODY_SPEC['nu']} " f"(musclemimic spec)",
+            f"myofullbody.xml has {m.nu} actuators, expected {MUSCLEMIMIC_FULLBODY_SPEC['nu']} (musclemimic spec)",
         )
 
     def test_myofullbody_report(self):

--- a/tests/test_torso_muscle_symmetry.py
+++ b/tests/test_torso_muscle_symmetry.py
@@ -54,4 +54,3 @@ def test_discovered_torso_muscle_pairs_have_symmetric_curves(torso_model_context
             failures.append((pair.label, summary))
 
     assert not failures
-


### PR DESCRIPTION
Renames the ambiguous single-letter variable l to left (E741) and adds a trailing newline (W292) in tests/muscle_analysis_utils.py. These two violations cause the CI lint job to fail.