### PR TITLE
Fix package-data globs and add installability smoke tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ include = ["myo_sim*"]
 
 [tool.setuptools.package-data]
 myo_sim = [
+    "models/*",
     "models/**/*",
+    "build/*",
     "build/**/*",
 ]
 

--- a/tests/test_package_install.py
+++ b/tests/test_package_install.py
@@ -1,0 +1,28 @@
+"""Smoke tests that verify the installed myo_sim package is complete and functional."""
+
+from __future__ import annotations
+
+import myo_sim
+
+
+def test_models_dir_exists():
+    assert myo_sim.MODELS_DIR.exists(), f"MODELS_DIR not found: {myo_sim.MODELS_DIR}"
+
+
+def test_xml_files_present():
+    xml_files = list(myo_sim.MODELS_DIR.rglob("*.xml"))
+    assert len(xml_files) > 0, "No .xml files found under MODELS_DIR"
+
+
+def test_stl_files_present():
+    stl_files = list(myo_sim.MODELS_DIR.rglob("*.stl"))
+    assert len(stl_files) > 0, "No .stl files found under MODELS_DIR"
+
+
+def test_load_myolegs():
+    model, data = myo_sim.load("myolegs")
+    assert model.njnt > 0, "Loaded myolegs model has no joints"
+
+
+def test_build_compose_import():
+    from myo_sim.build.compose import build_model  # noqa: F401


### PR DESCRIPTION
setuptools **/* globs do not match files placed directly in the root of the glob target directory — only files in subdirectories. myo_sim/models/README_hand.md and myo_sim/build/README.md would be silently dropped from any built wheel or sdist. Adds models/* and build/* alongside the existing recursive patterns to cover root-level files. Adds tests/test_package_install.py with five smoke tests covering MODELS_DIR existence, XML/STL presence, model loading via the registry, and build import.