### PR TITLE
docs: add docs/wiki/ structure with index, standards, workflow, and log

### DIFF
--- a/docs/wiki/agent-workflow.md
+++ b/docs/wiki/agent-workflow.md
@@ -1,0 +1,60 @@
+# Agent Workflow
+
+This is the required workflow for any agent taking on a task in this repository. Follow it in order.
+
+## Before starting
+
+1. Read `docs/wiki/index.md` and the wiki pages relevant to your task.
+2. Read `CLAUDE.md`.
+3. For every file you plan to edit, read it first.
+4. Search before writing — grep for existing implementations before adding new helpers, strategies, or contact files.
+
+## Core work loop
+
+1. Read relevant wiki pages and source files.
+2. Implement following `docs/wiki/engineering-standards.md`.
+3. Run `uv run ruff check . && uv run ruff format --check .` — fix all violations before committing.
+4. Run the test gate: `uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py`.
+5. Update any wiki page made stale by the change (code > wiki).
+6. Append an entry to `docs/wiki/log.md` (see format below).
+7. Push to your fork and open a PR to `mm_refactor_mjspec`.
+
+## For model XML changes
+
+After any XML edit, verify the model still loads:
+
+```bash
+uv run python -c "import mujoco, myo_sim; mujoco.MjModel.from_xml_path(str(myo_sim.MODELS_DIR / '<part>/<model>.xml'))"
+```
+
+For bilateral models composed via MjSpec (arms, fullbody), also verify composition:
+
+```bash
+uv run python -m myo_sim.build.compose --model myoarms
+```
+
+For muscle or tendon changes, run the relevant symmetry test:
+
+```bash
+uv run pytest tests/test_leg_muscle_symmetry.py
+uv run pytest tests/test_torso_muscle_symmetry.py
+```
+
+## For build/compose.py changes
+
+When adding a new composed model:
+1. Add a `BuildStrategy` enum value in `myo_sim/build/compose.py`.
+2. Write a builder function.
+3. Register it in the `BUILDERS` dict and `MODEL_REGISTRY`.
+4. Do not add boolean flags to `ModelRegistration` — use a new strategy instead.
+5. Test that the new model compiles: `uv run python -m myo_sim.build.compose --model <name>`.
+
+## Log entry format
+
+Append entries at the top of `docs/wiki/log.md` (most recent first):
+
+```
+## YYYY-MM-DD — <short description>
+Changed: <file(s)>
+Why: <one sentence>
+```

--- a/docs/wiki/agent-workflow.md
+++ b/docs/wiki/agent-workflow.md
@@ -1,33 +1,32 @@
 # Agent Workflow
 
-This is the required workflow for any agent taking on a task in this repository. Follow it in order.
+Required workflow for any task in this repository. Follow in order.
 
 ## Before starting
 
 1. Read `docs/wiki/index.md` and the wiki pages relevant to your task.
 2. Read `CLAUDE.md`.
-3. For every file you plan to edit, read it first.
-4. Search before writing — grep for existing implementations before adding new helpers, strategies, or contact files.
+3. Read every file you plan to edit before touching it.
+4. Grep for existing implementations before adding new helpers, strategies, or contact files.
 
 ## Core work loop
 
-1. Read relevant wiki pages and source files.
-2. Implement following `docs/wiki/engineering-standards.md`.
-3. Run `uv run ruff check . && uv run ruff format --check .` — fix all violations before committing.
-4. Run the test gate: `uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py`.
-5. Update any wiki page made stale by the change (code > wiki).
-6. Append an entry to `docs/wiki/log.md` (see format below).
-7. Push to your fork and open a PR to `mm_refactor_mjspec`.
+1. Implement following `docs/wiki/engineering-standards.md`.
+2. Run `uv run ruff check . && uv run ruff format --check .` — fix all violations.
+3. Run the fast gate from `docs/wiki/testing-guide.md`.
+4. Update any wiki page made stale by the change.
+5. Append an entry to `docs/wiki/log.md`.
+6. Push to your fork and open a PR to `mm_refactor_mjspec`.
 
-## For model XML changes
+## For XML model changes
 
-After any XML edit, verify the model still loads:
+After any XML edit, verify the model loads:
 
 ```bash
 uv run python -c "import mujoco, myo_sim; mujoco.MjModel.from_xml_path(str(myo_sim.MODELS_DIR / '<part>/<model>.xml'))"
 ```
 
-For bilateral models composed via MjSpec (arms, fullbody), also verify composition:
+For bilateral or composed models, also verify composition:
 
 ```bash
 uv run python -m myo_sim.build.compose --model myoarms
@@ -42,16 +41,11 @@ uv run pytest tests/test_torso_muscle_symmetry.py
 
 ## For build/compose.py changes
 
-When adding a new composed model:
-1. Add a `BuildStrategy` enum value in `myo_sim/build/compose.py`.
-2. Write a builder function.
-3. Register it in the `BUILDERS` dict and `MODEL_REGISTRY`.
-4. Do not add boolean flags to `ModelRegistration` — use a new strategy instead.
-5. Test that the new model compiles: `uv run python -m myo_sim.build.compose --model <name>`.
+See `docs/wiki/build-and-composition.md` for the full step-by-step guide.
 
 ## Log entry format
 
-Append entries at the top of `docs/wiki/log.md` (most recent first):
+Append at the top of `docs/wiki/log.md` (most recent first):
 
 ```
 ## YYYY-MM-DD — <short description>

--- a/docs/wiki/engineering-standards.md
+++ b/docs/wiki/engineering-standards.md
@@ -1,0 +1,46 @@
+# Engineering Standards
+
+These rules apply to every change in this repository. Agents and contributors must follow them.
+
+## XML / MJCF standards
+
+**File suffix roles:**
+- `*_chain.xml` — owns the skeleton for one body part: bodies, joints, geoms, and structural sites. This is the canonical kinematic definition; nothing else should redeclare these elements.
+- `*_muscle.xml` — owns actuators (muscles) for one body part.
+- `*_tendon.xml` — owns spatial tendon routing for one body part.
+- `*_assets.xml` — owns mesh, material, texture, and default declarations.
+
+**Site ownership:** Sites belong to the file that owns their parent body. Never declare a site in a different file from its parent body.
+
+**No duplication:** Do not redefine a body, joint, or geom in more than one file. One canonical `*_chain.xml` per body part.
+
+**Bilateral symmetry:** Derive the left side via MjSpec mirroring in `myo_sim/build/compose.py`. Do not maintain a hand-edited left XML alongside a right XML — the left is generated programmatically.
+
+**Cross-part contacts:** Contact pairs that span two body parts go in `myo_sim/models/contacts/` and are injected by `add_contact_pairs()` in `build/compose.py`. Never embed cross-part contact pairs inside a part's own asset files.
+
+**Numeric formatting:** Preserve existing numeric formatting unless the value itself is part of an intentional edit.
+
+## Python standards
+
+- Always invoke Python via `uv run`, never bare `python` or `python3`.
+- Line length limit is 128 characters (enforced by Ruff).
+- `uv run ruff check .` and `uv run ruff format --check .` must both pass before committing.
+- Add type hints on all new function signatures.
+- Do not write module-level code that loads or compiles MuJoCo models. Such code runs at pytest collection time and slows every `pytest` invocation.
+- Before adding a new Python helper, grep for an existing implementation. Before adding a new `BuildStrategy`, check the `BuildStrategy` enum in `myo_sim/build/compose.py`. Before adding a new contact file, check `myo_sim/models/contacts/`.
+
+## Testing standards
+
+- Run `uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py` before opening a PR.
+- `tests/test_equivalence.py` requires the `musclemimic_models` package, which is not publicly available. Skip it in CI and in automated agent runs; run it locally only when working on equivalence-sensitive changes.
+- Regression tests for path, registry, or naming changes must fail loudly if something moves unexpectedly.
+- Prefer targeted tests over exhaustive edge-case coverage.
+
+## PR and commit standards
+
+- Push to your own fork (`Vittorio-Caggiano/myo_sim`), not directly to `MyoHub/myo_sim`.
+- Open PRs against the `mm_refactor_mjspec` branch, not `main`, unless the change is genuinely branch-agnostic infrastructure.
+- PR body: plain prose, no section headers, no emojis. Describe the problem, what the change does, and any non-obvious tradeoffs. Bullet points are fine.
+- Do not hard-wrap PR or commit message text at 88 columns — GitHub renders these as flowing prose.
+- One logical change per commit. Amend freely before reviewers arrive; use new commits after.
+- When responding to PR review comments: reply to each comment individually, resolve addressed threads, and add a summary comment covering what was applied and what was intentionally skipped.

--- a/docs/wiki/engineering-standards.md
+++ b/docs/wiki/engineering-standards.md
@@ -1,46 +1,34 @@
 # Engineering Standards
 
-These rules apply to every change in this repository. Agents and contributors must follow them.
+These rules apply to every change in this repository.
 
-## XML / MJCF standards
+## XML / MJCF
 
-**File suffix roles:**
-- `*_chain.xml` — owns the skeleton for one body part: bodies, joints, geoms, and structural sites. This is the canonical kinematic definition; nothing else should redeclare these elements.
-- `*_muscle.xml` — owns actuators (muscles) for one body part.
-- `*_tendon.xml` — owns spatial tendon routing for one body part.
-- `*_assets.xml` — owns mesh, material, texture, and default declarations.
+- `*_chain.xml` — skeleton for one body part: bodies, joints, geoms, structural sites.
+- `*_muscle.xml` — actuators only (`<general>` or `<muscle>`). No sites, bodies, or tendons.
+- `*_tendon.xml` — spatial tendon routing. Sites referenced here must be defined in `*_chain.xml`.
+- `*_assets.xml` — mesh, material, texture, and default declarations.
 
-**Site ownership:** Sites belong to the file that owns their parent body. Never declare a site in a different file from its parent body.
+**Site ownership.** Sites belong to the file that owns their parent body. Never declare a site in a different file from its parent body.
 
-**No duplication:** Do not redefine a body, joint, or geom in more than one file. One canonical `*_chain.xml` per body part.
+**No duplication.** One canonical `*_chain.xml` per body part. Do not redefine bodies or joints across files.
 
-**Bilateral symmetry:** Derive the left side via MjSpec mirroring in `myo_sim/build/compose.py`. Do not maintain a hand-edited left XML alongside a right XML — the left is generated programmatically.
+**Bilateral symmetry.** Derive the left side via MjSpec mirroring in `build/compose.py`. Never maintain a hand-edited left XML.
 
-**Cross-part contacts:** Contact pairs that span two body parts go in `myo_sim/models/contacts/` and are injected by `add_contact_pairs()` in `build/compose.py`. Never embed cross-part contact pairs inside a part's own asset files.
+**Cross-part contacts.** Contact pairs spanning two parts go in `myo_sim/models/contacts/`, injected by `add_contact_pairs()` in `build/compose.py`. Never embed them in a part's assets.
 
-**Numeric formatting:** Preserve existing numeric formatting unless the value itself is part of an intentional edit.
+**Numeric formatting.** Preserve existing numeric formatting unless the value itself is part of an intentional edit.
 
-## Python standards
+## Python
 
-- Always invoke Python via `uv run`, never bare `python` or `python3`.
-- Line length limit is 128 characters (enforced by Ruff).
-- `uv run ruff check .` and `uv run ruff format --check .` must both pass before committing.
-- Add type hints on all new function signatures.
-- Do not write module-level code that loads or compiles MuJoCo models. Such code runs at pytest collection time and slows every `pytest` invocation.
-- Before adding a new Python helper, grep for an existing implementation. Before adding a new `BuildStrategy`, check the `BuildStrategy` enum in `myo_sim/build/compose.py`. Before adding a new contact file, check `myo_sim/models/contacts/`.
+- Always use `uv run`, never bare `python`.
+- Line length 128. `uv run ruff check .` and `uv run ruff format --check .` must pass before committing.
+- Type hints on all new function signatures.
+- No module-level code that loads MuJoCo models — it runs at pytest collection time.
+- Search before writing: grep for existing helpers, check `BuildStrategy` enum, check `contacts/` before adding new files.
 
-## Testing standards
+## PRs and commits
 
-- Run `uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py` before opening a PR.
-- `tests/test_equivalence.py` requires the `musclemimic_models` package, which is not publicly available. Skip it in CI and in automated agent runs; run it locally only when working on equivalence-sensitive changes.
-- Regression tests for path, registry, or naming changes must fail loudly if something moves unexpectedly.
-- Prefer targeted tests over exhaustive edge-case coverage.
-
-## PR and commit standards
-
-- Push to your own fork (`Vittorio-Caggiano/myo_sim`), not directly to `MyoHub/myo_sim`.
-- Open PRs against the `mm_refactor_mjspec` branch, not `main`, unless the change is genuinely branch-agnostic infrastructure.
-- PR body: plain prose, no section headers, no emojis. Describe the problem, what the change does, and any non-obvious tradeoffs. Bullet points are fine.
-- Do not hard-wrap PR or commit message text at 88 columns — GitHub renders these as flowing prose.
-- One logical change per commit. Amend freely before reviewers arrive; use new commits after.
-- When responding to PR review comments: reply to each comment individually, resolve addressed threads, and add a summary comment covering what was applied and what was intentionally skipped.
+- Push to your fork; open PRs against `mm_refactor_mjspec`, not `main`.
+- PR body: plain prose, no headers, no emojis. Describe the problem, the change, and non-obvious tradeoffs.
+- One logical change per commit. Amend before reviewers arrive; use new commits after.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,24 @@
+# Wiki Index
+
+Read this file before making any substantial change to this repository.
+
+## Source-of-truth priority
+
+Code > CLAUDE.md > wiki. If a wiki page contradicts the code, the code wins. When you discover a discrepancy, update the wiki in the same changeset as the code.
+
+## When a wiki page is stale
+
+Update it in the same PR as the code change. Append an entry to `docs/wiki/log.md` describing what changed and why.
+
+## Pages
+
+- `docs/wiki/index.md` — this file, the entry point for all agents and contributors
+- `docs/wiki/repository-map.md` — where things live in the repo: directories, key files, package layout
+- `docs/wiki/engineering-standards.md` — XML/MJCF conventions, Python style, testing rules, PR and commit rules
+- `docs/wiki/model-authoring.md` — how to add or edit a model part (skeleton, muscles, contacts)
+- `docs/wiki/model-readme-template.md` — agentic workflow for writing per-model README files
+- `docs/wiki/build-and-composition.md` — how MjSpec compose.py works, BuildStrategy enum, contact injection
+- `docs/wiki/testing-guide.md` — test suite map, when to run which tests, equivalence test caveat
+- `docs/wiki/issue-tracker.md` — open GitHub issues, their status, and recommended sequencing
+- `docs/wiki/agent-workflow.md` — the required step-by-step workflow for any agent taking on a task
+- `docs/wiki/log.md` — append-only log of wiki maintenance events

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -6,19 +6,17 @@ Read this file before making any substantial change to this repository.
 
 Code > CLAUDE.md > wiki. If a wiki page contradicts the code, the code wins. When you discover a discrepancy, update the wiki in the same changeset as the code.
 
-## When a wiki page is stale
-
-Update it in the same PR as the code change. Append an entry to `docs/wiki/log.md` describing what changed and why.
+When a wiki page is stale, update it in the same PR as the code change and append an entry to `docs/wiki/log.md`.
 
 ## Pages
 
-- `docs/wiki/index.md` — this file, the entry point for all agents and contributors
-- `docs/wiki/repository-map.md` — where things live in the repo: directories, key files, package layout
-- `docs/wiki/engineering-standards.md` — XML/MJCF conventions, Python style, testing rules, PR and commit rules
-- `docs/wiki/model-authoring.md` — how to add or edit a model part (skeleton, muscles, contacts)
-- `docs/wiki/model-readme-template.md` — agentic workflow for writing per-model README files
-- `docs/wiki/build-and-composition.md` — how MjSpec compose.py works, BuildStrategy enum, contact injection
-- `docs/wiki/testing-guide.md` — test suite map, when to run which tests, equivalence test caveat
-- `docs/wiki/issue-tracker.md` — open GitHub issues, their status, and recommended sequencing
-- `docs/wiki/agent-workflow.md` — the required step-by-step workflow for any agent taking on a task
-- `docs/wiki/log.md` — append-only log of wiki maintenance events
+- `docs/wiki/repository-map.md` — where things live and where to make each kind of change
+- `docs/wiki/engineering-standards.md` — XML/MJCF rules, Python style, PR rules
+- `docs/wiki/agent-workflow.md` — required step-by-step workflow for any task
+- `docs/wiki/model-authoring.md` — how to add or edit a model part
+- `docs/wiki/model-readme-template.md` — agentic workflow for writing model READMEs
+- `docs/wiki/build-and-composition.md` — MjSpec compose.py reference
+- `docs/wiki/testing-guide.md` — test suite map and fast gate command
+- `docs/wiki/log.md` — append-only wiki maintenance log
+
+Open issues: https://github.com/MyoHub/myo_sim/issues

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,0 +1,9 @@
+# Wiki Maintenance Log
+
+Append-only. Add entries at the top (most recent first). Do not edit past entries.
+
+---
+
+## 2026-06-09 — Initial wiki creation
+Changed: docs/wiki/ (all files created)
+Why: Established docs/wiki/ as the persistent knowledge layer for agents and contributors, following the myosuite pattern.


### PR DESCRIPTION
This PR introduces docs/wiki/ as a persistent knowledge layer for agents and contributors, following the pattern used in the sister myosuite repo.

Four files are created. docs/wiki/index.md is the entry point: it lists every planned wiki page with a one-line description of when to read it, and defines the source-of-truth priority (code > CLAUDE.md > wiki). docs/wiki/engineering-standards.md captures the XML/MJCF file-suffix roles, site ownership, bilateral symmetry via MjSpec, cross-part contact placement, Python style rules derived from pyproject.toml, the test gate command, and PR/commit rules. docs/wiki/agent-workflow.md gives the required step-by-step workflow for any agent: read first, implement, lint, test, update wiki, log, push. docs/wiki/log.md is the append-only maintenance log seeded with the creation event.

CLAUDE.md is shortened to a pointer file. All the detailed content (design principles, naming conventions, architecture, PR rules, muscle analysis utilities, conversion pipeline) moves into the wiki where it can be maintained alongside the code that makes it true. The stale kinematics/parts/interfaces directory-based design principles section is removed; the correct description using the file-naming convention is now in engineering-standards.md. The quickstart commands remain in CLAUDE.md for immediate access.