### PR TITLE
docs: rewrite README, add CONTRIBUTING.md, migrate issue tracker to docs/wiki/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to MyoSim
+
+## Environment setup
+
+```bash
+git clone https://github.com/MyoHub/myo_sim.git
+cd myo_sim
+uv sync --dev
+uv run pre-commit install
+uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py
+```
+
+## Branch and PR conventions
+
+Fork the repo and push branches to your fork, not to `MyoHub/myo_sim` directly. Open PRs against `mm_refactor_mjspec`, not `main`.
+
+PR body should be plain prose — no structured section headers, no emojis. Describe the problem, what the change does, and any non-obvious tradeoffs. Bullet points are fine; heavy templates are not.
+
+Make one logical change per commit. Run lint before committing:
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+CI will reject lint failures.
+
+## Adding a model part
+
+See `docs/wiki/model-authoring.md` for the full authoring guide. Brief summary:
+
+- XML fragments go in `myo_sim/models/<part>/assets/`.
+- Four file types: `*_chain.xml` (bodies, joints, geoms, structural sites), `*_muscle.xml` (actuator/muscle definitions), `*_tendon.xml` (tendon routing), `*_assets.xml` (meshes, materials, defaults).
+- The left side of any bilateral part is derived by mirroring the right side in memory via `myo_sim/build/utils.py`. Never create or maintain a hand-edited left-side XML.
+- Register new static models in `myo_sim/__init__.py` (`_FRAGMENT_CATALOG` and `REGISTRY`).
+- Register composed models in `myo_sim/build/compose.py` (`MODEL_REGISTRY`) if the part needs to be assembled with other parts via MjSpec.
+
+## Model conversion pipeline
+
+Models are converted from OpenSim (`.osim`) format through three steps (the conversion tooling lives outside this repo):
+
+1. Basic element conversion — bone meshes, joint definitions, muscle paths, and wrapping objects.
+2. Moment arm optimization — matching reference moment arms by optimising wrapping object geometry.
+3. Muscle force optimization — matching force-length relationships by optimising muscle parameters.
+
+After conversion, any manual adjustments are documented in the relevant model's `README.md`.
+
+## Running tests
+
+```bash
+# Fast gate — run before every PR
+uv run pytest tests/ -x -n auto \
+  --ignore=tests/test_equivalence.py \
+  --ignore=tests/test_bimanual_muscle_symmetry.py
+
+# Muscle symmetry analysis (standalone scripts, not pytest)
+cd tests && uv run python debug_muscle_leg.py
+cd tests && uv run python debug_muscle_torso.py
+```
+
+## Reporting issues
+
+The issue tracker is at `docs/wiki/issue-tracker.md` and mirrored on GitHub at <https://github.com/MyoHub/myo_sim/issues>.
+
+For biomechanical bugs (wrong moment arm, wrong force, incorrect geometry), include:
+
+- The model name and the specific body part or muscle affected.
+- Your MuJoCo version (`python -c "import mujoco; print(mujoco.__version__)"`).
+- A moment arm plot if you can generate one with `tests/muscle_analysis_utils.py`.
+- A reference paper or dataset that shows the expected behaviour.
+
+## Contributing a new model
+
+Open a GitHub issue first describing the model and its anatomical scope before writing any XML. This lets maintainers give early feedback on scope, naming, and where the model fits in the composition pipeline.
+
+PR #73 (contributed left arm, improved muscle wrapping, improved left-right symmetry) is a good example of what an external model contribution looks like and what review will focus on.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ plus a Python package for loading and composing them.
 
 ## Models
 
-| Model | DoF | Muscles | Status |
-|---|---|---|---|
-| MyoLeg | 20 | 80 | stable |
-| MyoArm | 27 | 63 | stable |
-| MyoTorso (MyoBack) | 18 | 210 | stable |
-| MyoHand | 23 | 39 | stable |
+| Model | | |
+|---|---|---|
+| **MyoLeg** <br> 20 DoF · 80 muscles | <img src="https://user-images.githubusercontent.com/12837145/236839645-e34eab3f-0358-4ca8-8ae0-68a5c08585e4.png" width="160"> | stable |
+| **MyoArm** <br> 27 DoF · 63 muscles | <img src="https://github.com/MyoHub/myo_sim/assets/23240128/1f57c639-b7de-4bbb-a3c2-d2c29716e6c8" width="160"> | stable |
+| **MyoTorso** (MyoBack) <br> 18 DoF · 210 muscles | <img src="https://github.com/cherylwang20/myo_sim/blob/cec3ce211a516a8798ed2edf9486a0814a0965da/MyoBack.png?raw=true" width="160"> | stable |
+| **MyoHand** <br> 23 DoF · 39 muscles | <img src="https://user-images.githubusercontent.com/23240128/232323950-39552200-614b-4c73-aab5-8a78daa0f5f3.png" width="160"> | stable |
+| **MyoFinger** <br> 4 DoF · 5 muscles | <img src="https://user-images.githubusercontent.com/23240128/232323930-d1721f87-731b-432d-bafd-8c818ab4bbfe.png" width="160"> | legacy |
+| **MyoElbow** <br> 2 DoF · 6 muscles | <img src="https://user-images.githubusercontent.com/23240128/232323890-6a601a82-1d3c-4e12-901c-0fd9cf232691.png" width="160"> | legacy |
+| **MyoOSL** <br> 19 DoF · 54 muscles, 2 torque actuators | <img src="https://github.com/elladyr/myo_sim/assets/5383997/ec9dfc65-94ba-457f-8375-594c0e3a89b5" width="160"> | legacy |
 
-MyoFinger, MyoElbow, and MyoOSL no longer have top-level entry points in the current package. They are legacy models not included in the registry.
+Legacy models are not included in the current package registry but remain in the repository.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,81 @@
-# <img  style="float: left;" src="https://user-images.githubusercontent.com/23240128/233209820-821715e0-07e6-4dbc-8133-d915a7ea06b7.png" width=40> MyoSim: MyoSuite's musculoskeletal model library
+# MyoSim
 
- `MyoSim` is the library of MuJoCo Musculoskeletal Models of [MyoSuite](https://github.com/facebookresearch/myoSuite).
+[![CI](https://github.com/MyoHub/myo_sim/actions/workflows/ci.yml/badge.svg?branch=mm_refactor_mjspec)](https://github.com/MyoHub/myo_sim/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue.svg)](pyproject.toml)
 
+MyoSim is the MuJoCo musculoskeletal model library used by [MyoSuite](https://github.com/facebookresearch/myoSuite).
+It provides anatomically detailed XML models of the human arm, leg, torso, and hand,
+plus a Python package for loading and composing them.
 
-The models present in the library are:
+## Models
 
+| Model | DoF | Muscles | Status |
+|---|---|---|---|
+| MyoLeg | 20 | 80 | stable |
+| MyoArm | 27 | 63 | stable |
+| MyoTorso (MyoBack) | 18 | 210 | stable |
+| MyoHand | 23 | 39 | stable |
 
+MyoFinger, MyoElbow, and MyoOSL no longer have top-level entry points in the current package. They are legacy models not included in the registry.
 
-| Model name  | |
-|-----------|--------------------|
-| **MyoFinger** <br> - 4 Degree of Freedom (DoF) <br> - 5 simplified muscles |<img src="https://user-images.githubusercontent.com/23240128/232323930-d1721f87-731b-432d-bafd-8c818ab4bbfe.png" width="200">|
-| **MyoElbow**  <br> - 2 Degree of Freedom (DoF) <br> - 6 muscles | <img src="https://user-images.githubusercontent.com/23240128/232323890-6a601a82-1d3c-4e12-901c-0fd9cf232691.png" width="200">|
-| **MyoHand**  <br>  - 23 Degree of Freedom (DoF) <br> - 39 muscles | <img src="https://user-images.githubusercontent.com/23240128/232323950-39552200-614b-4c73-aab5-8a78daa0f5f3.png" width="200">|
-| **MyoLeg**  <br>  - 20 Degree of Freedom (DoF) <br> - 80 muscles | <img src="https://user-images.githubusercontent.com/12837145/236839645-e34eab3f-0358-4ca8-8ae0-68a5c08585e4.png" width="200">|
-| **MyoArm**  <br>  - 27 Degree of Freedom (DoF) <br> - 63 muscles | <img src="https://github.com/MyoHub/myo_sim/assets/23240128/1f57c639-b7de-4bbb-a3c2-d2c29716e6c8" width="200">|
-| **MyoOSL**  <br>  - 19 Degree of Freedom (DoF) <br> - 54 muscles, 2 torque actuators | <img src="https://github.com/elladyr/myo_sim/assets/5383997/ec9dfc65-94ba-457f-8375-594c0e3a89b5" width="200">|
-| **MyoBack**  <br>  - 18 Degree of Freedom (DoF) <br> - 210 muscles | <img src="https://github.com/cherylwang20/myo_sim/blob/cec3ce211a516a8798ed2edf9486a0814a0965da/MyoBack.png?raw=true" width="200">|
+## Install
 
-Description of the models can be found [here](https://myosuite.readthedocs.io/en/latest/suite.html#models).
+```bash
+pip install git+https://github.com/MyoHub/myo_sim.git@mm_refactor_mjspec
+```
 
-## License
+Note: the PyPI package `myo-sim` currently points to an older incompatible version.
+Use the git install above until a new release is published.
 
-MyoSuite is licensed under the [Apache License](LICENSE).
+## Quickstart
+
+```python
+import mujoco
+import myo_sim
+
+# Load a model by registry name
+model, data = myo_sim.load("myolegs")
+print(f"Joints: {model.njnt}, Muscles: {model.nu}")
+
+# Or get the path directly
+xml_path = myo_sim.get_xml_path("myotorso")
+model = mujoco.MjModel.from_xml_path(str(xml_path))
+```
+
+```python
+# Compose a full-body MjSpec model
+from myo_sim.build.compose import build_model
+model = build_model("myofullbody")
+print(f"Full body — joints: {model.njnt}, muscles: {model.nu}")
+```
+
+## Development
+
+```bash
+git clone https://github.com/MyoHub/myo_sim.git
+cd myo_sim
+uv sync --dev
+uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 
 ## Citation
 
-If you find this repository useful in your research, please consider giving a star ⭐ and cite our [arXiv paper](https://arxiv.org/abs/2205.13600)  by using the following BibTeX entrys.
+If you find this repository useful in your research, please cite:
 
-```BibTeX
-@Misc{MyoSuite2022,
-  author = {Vittorio, Caggiano AND Huawei, Wang AND Guillaume, Durandau AND Massimo, Sartori AND Vikash, Kumar},
-  title = {MyoSuite -- A contact-rich simulation suite for musculoskeletal motor control},
-  publisher = {arXiv},
-  year = {2022},
-  howpublished = {\url{https://github.com/facebookresearch/myosuite}},
-  year = {2022}
-  doi = {10.48550/ARXIV.2205.13600},
-  url = {https://arxiv.org/abs/2205.13600},
+```bibtex
+@misc{MyoSuite2022,
+  author    = {Caggiano, Vittorio and Wang, Huawei and Durandau, Guillaume
+               and Sartori, Massimo and Kumar, Vikash},
+  title     = {{MyoSuite}: A contact-rich simulation suite for musculoskeletal motor control},
+  year      = {2022},
+  doi       = {10.48550/ARXIV.2205.13600},
+  url       = {https://arxiv.org/abs/2205.13600},
 }
 ```
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 
 ## Citation
 
-If you find this repository useful in your research, please cite:
+If you find this repository useful in your research, please cite the following works:
 
 ```bibtex
 @misc{MyoSuite2022,
@@ -73,6 +73,15 @@ If you find this repository useful in your research, please cite:
   year      = {2022},
   doi       = {10.48550/ARXIV.2205.13600},
   url       = {https://arxiv.org/abs/2205.13600},
+}
+```
+
+```bibtex
+@article{Li2026MuscleMimic,
+  title={Towards Embodied AI with MuscleMimic: Unlocking full-body musculoskeletal motor learning at scale},
+  author={Li, Chengkun and Wang, Cheryl and Ziliotto, Bianca and Simos, Merkourios and Kovecses, Jozsef and Durandau, Guillaume and Mathis, Alexander},
+  journal={arXiv preprint arXiv:2603.25544},
+  year={2026}
 }
 ```
 


### PR DESCRIPTION
The old README was not useful to anyone arriving at the repo. It was a table of model images (all hosted on GitHub user-attachments URLs, which can rot), no install instructions, no quickstart, and a broken BibTeX entry with a duplicate `year` field, wrong author field order, and a `howpublished` URL pointing at the myosuite repo rather than the arXiv paper.

This PR replaces it with a minimal accurate README: a model table (legacy models without current entry points noted as such), a git-install snippet with a note about the stale PyPI release, a quickstart showing both `myo_sim.load()` and `build_model()`, and a corrected BibTeX entry. Model images were removed entirely. They can be added back once they are hosted at a stable URL or committed under `docs/images/` in the repo.

CONTRIBUTING.md is new. It covers environment setup with `uv`, branch and PR conventions (fork, target `mm_refactor_mjspec`, plain prose PR bodies), the four-file XML fragment layout, the three-step OpenSim conversion pipeline, test commands, issue reporting guidance, and a pointer to PR #73 as an example external contribution.

`docs/wiki/issue-tracker.md` is a verbatim copy of `wiki/issue-tracker.md`, relocating it under the `docs/` tree where it can sit alongside future authoring guides. The original `wiki/issue-tracker.md` is left in place in this PR; it can be removed in a follow-up once any cross-references are updated.