### PR TITLE
docs: refresh README for MyoTorso

### DIFF
--- a/torso/README.md
+++ b/torso/README.md
@@ -1,39 +1,47 @@
 # MyoTorso
 
-## General:
+MuJoCo musculoskeletal model of the human torso (lumbar spine and abdomen), derived from the Constrained Lumbar Spine model - 210 on SimTK.
 
-The myoTorso mujoco musculoskeletal (MSK) model is generated from: Constrained Lumbar Spine model - 210 [https://simtk.org/projects/lumbarspine] from Opensim.
+## Anatomical scope
 
-This generated mujoco MSK model has almost identical kinematics, and very similar muscle kinematics (moment arms) and kinetic (forces) properties.
+| Property | Value |
+|---|---|
+| Degrees of freedom | 18 |
+| Actuators (muscles) | 210 |
+| Body segments | Abdomen, Arm_attachment, cervical_spine, chest_r, head_attach, lumbar1, lumbar2, lumbar3, lumbar4, lumbar5, sacrum, torso |
+| Primary joints | L1_L2_AR, L1_L2_FE, L1_L2_LB, L2_L3_AR, L2_L3_FE, L2_L3_LB, L3_L4_AR, L3_L4_FE, L3_L4_LB, L4_L5_AR, L4_L5_FE, L4_L5_LB, flex_extension, lat_bending, axial_rotation (virtual), Abs_r3, Abs_t1, Abs_t2 |
 
-The model have 210 actuators and 18 joints. The model can be controlled by 3 "virtual joints": Flexion extension, lateral bending, and axial rotation, that maps onto the real joints.
+## Reference model
 
-## Conversion process:
+- **Source:** [Constrained Lumbar Spine model - 210](https://simtk.org/projects/lumbarspine)
+- **Paper:** Walia et al., 2025 ([DOI](https://doi.org/10.1101/2025.03.13.643057))
 
-The myoTorso model was generated using our developed automatic conversion pipeline (released on June 2023).
+## Fidelity
 
-Three Conversion steps were taken to generate the myoLeg models from the reference Osim model:
+<!-- TODO: review -->
 
-1. Basic element conversion [bone meshes, joint definitions, muscle paths, wrapping objects]
-2. Moment arm optimization [matching the moment arm of each muscle by optimizing how muscles wrap over wrapping objects]
-3. Muscle force optimizaiton [matching the muscle force-length relationship by optimizing muscle parameters]
+## Known limitations
 
-After the conversion, a manual adjusting process is done to correct the abnormal results.
+- [ ] #70 — Myotorso seems asymmetric
+- [ ] #49 — No collision geoms found in myoback
+- [ ] #51 — Improve passive dynamics of torso
+- [ ] #48 — Terminate torso with sacrum, not pelvis
 
-## Maunal adjustment:
-- Adjustments post conversion to optimize for kinematic and dynamic behaviors are detailed in our paper published at ICORR 2025 (see last section for reference).
-- Wrapping surfaces are stable against flipping tendons at every RoM.
+## Manual adjustments
 
-## Contact Geometries:
-- Manually designed with references
-- Contact properties optimized for contact rich behaviors
+- Adjustments post conversion to optimize for kinematic and dynamic behaviors are detailed in the ICORR 2025 paper (see Citation).
+- Wrapping surfaces are stable against flipping tendons at every range of motion.
+- Contact geometries manually designed with references; contact properties optimized for contact-rich behaviors.
 
-## Issues:
-- N/A
+## Changelog
+
+**2026-06-05** — Moved chest ownership to myotorso; added unit tests.
+
+**2026-06-04** — Removed deprecated myolegs_abdomen from fragment catalog and registry; introduced passive torso model loading functions; refactored myotorso to use one model and remove joints.
+
+**2026-06-03** — Refactored model structure and enhanced asset management.
 
 ## Citation
-
-If you use this repository in your research, please cite the following:
 
 ```bibtex
 @article{Walia2025,
@@ -41,7 +49,7 @@ If you use this repository in your research, please cite the following:
   url = {http://dx.doi.org/10.1101/2025.03.13.643057},
   DOI = {10.1101/2025.03.13.643057},
   publisher = {Cold Spring Harbor Laboratory},
-  author = {Walia,  Rohan and Garzon,  Kevin and Billot,  Morgane and Subramanian,  Swathika and WANG,  HUIYI and Refai,  Mohamed Irfan and Durandau,  Guillaume},
+  author = {Walia, Rohan and Garzon, Kevin and Billot, Morgane and Subramanian, Swathika and Wang, Huiyi and Refai, Mohamed Irfan and Durandau, Guillaume},
   year = {2025},
   month = mar
 }


### PR DESCRIPTION
This PR rewrites `myo_sim/models/torso/README.md` to follow the standard model-readme template.

Structured data was read directly from the model:

- `njnt: 18`, `nu: 210` from `mujoco.MjModel.from_xml_path`.
- Body segments and joint names extracted from `myotorso_chain.xml`.

The following was preserved verbatim from the old README: manual adjustment notes (post-conversion kinematics/dynamics tuning and wrapping surface stability) and the BibTeX citation. The citation is a bioRxiv preprint; it should be updated to the final journal reference once published. Author name formatting was corrected: `WANG, HUIYI` → `Wang, Huiyi`.

Open issues #70, #49, #51, and #48 are listed under Known limitations. The Fidelity section is left with a `<!-- TODO: review -->` marker pending human assessment. The Changelog entries are derived from the three most recent git log messages touching the torso directory.