### PR TITLE
docs: add README for MyoHead

### DIFF
--- a/head/README.md
+++ b/head/README.md
@@ -1,0 +1,39 @@
+# MyoHead
+
+A simplified rigid kinematic head-and-neck model (no muscle actuators) derived from the HAT (Head-Arms-Trunk) body segment geometry used in OpenSim full-body models.
+
+## Anatomical scope
+
+| Property | Value |
+|---|---|
+| Degrees of freedom | 2 |
+| Actuators (muscles) | 0 — rigid kinematic scaffold only |
+| Body segments | neck, head |
+| Primary joints | neck_rotation, neck_flexion |
+
+## Reference model
+
+- **Source:** <!-- TODO: review — mesh names suggest HAT segment from an OpenSim full-body model; confirm exact source -->
+- **Paper:** <!-- TODO: review -->
+
+## Fidelity
+
+<!-- TODO: review -->
+
+## Known limitations
+
+- [ ] No muscle actuators — the model provides geometry and kinematics only; neck muscle forces are not represented.
+
+## Manual adjustments
+
+- Joint `neck_rotation` and `neck_flexion` were commented out in `myohead_rigid_chain.xml` to produce a fully locked (zero-DOF) rigid variant; `myohead_simple_chain.xml` re-enables both joints for the standard two-DOF configuration.
+
+## Changelog
+
+**2026-06-03** — Refactor model structure and enhance asset management.
+**2026-05-26** — Documentation pass; deprecated arm/elbow files removed from sibling directories.
+**2025-05-27** — Initial addition of head model alongside body and arm models.
+
+## Citation
+
+See repository README.


### PR DESCRIPTION
This PR adds an initial README for the `head/` model directory, following the standard model README template.

The content was inferred entirely from XML inspection and git history, since no prior documentation existed. Here is what was determined automatically and what still needs human input:

**Inferred from XML:**
- 2 degrees of freedom: `neck_rotation` (hinge, range ±1.4 rad) and `neck_flexion` (hinge, range −0.87 to 1.05 rad)
- 0 actuators — the model is a rigid kinematic scaffold with no muscle forces
- Two body segments: `neck` and `head`
- Meshes named `hat_cervical`, `hat_jaw`, `hat_skull` suggest derivation from the HAT (Head-Arms-Trunk) body segment geometry used in OpenSim full-body models
- A rigid variant (`myohead_rigid_chain.xml`) exists with both joints commented out, leaving the head fully locked; the simple chain re-enables both joints

**Fields marked `<!-- TODO: review -->`:**
- **Reference model / Source:** The mesh naming convention points toward an OpenSim HAT segment, but the exact source model URL has not been confirmed.
- **Paper:** No specific publication reference was found in the XML or git history.
- **Fidelity:** Requires a biomechanical reviewer to assess how well the two-DOF kinematic representation matches the actual cervical spine.