### PR TITLE
docs: add README for MyoHead

### DIFF
--- a/myo_sim/models/head/README.md
+++ b/myo_sim/models/head/README.md
@@ -1,0 +1,39 @@
+# MyoHead
+
+A simplified rigid kinematic head-and-neck model (no muscle actuators) derived from the HAT (Head-Arms-Trunk) body segment geometry used in OpenSim full-body models.
+
+## Anatomical scope
+
+| Property | Value |
+|---|---|
+| Degrees of freedom | 2 |
+| Actuators (muscles) | 0 — rigid kinematic scaffold only |
+| Body segments | neck, head |
+| Primary joints | neck_rotation, neck_flexion |
+
+## Reference model
+
+- **Source:** <!-- TODO: review — mesh names suggest HAT segment from an OpenSim full-body model; confirm exact source -->
+- **Paper:** <!-- TODO: review -->
+
+## Fidelity
+
+<!-- TODO: review -->
+
+## Known limitations
+
+- [ ] No muscle actuators — the model provides geometry and kinematics only; neck muscle forces are not represented.
+
+## Manual adjustments
+
+- Joint `neck_rotation` and `neck_flexion` were commented out in `myohead_rigid_chain.xml` to produce a fully locked (zero-DOF) rigid variant; `myohead_simple_chain.xml` re-enables both joints for the standard two-DOF configuration.
+
+## Changelog
+
+**2026-06-03** — Refactor model structure and enhance asset management.
+**2026-05-26** — Documentation pass; deprecated arm/elbow files removed from sibling directories.
+**2025-05-27** — Initial addition of head model alongside body and arm models.
+
+## Citation
+
+See repository README.


### PR DESCRIPTION
Creates myo_sim/models/head/README.md following the model-readme-template. MyoHead is a rigid kinematic scaffold (njnt=2, nu=0) with neck_rotation and neck_flexion joints only. Reference model source and paper left as TODO: review — HAT body origin inferred from mesh name prefix but not confirmed. All biomechanically uncertain fields marked for human review.