### PR TITLE
docs: enforce unique MuJoCo default class names in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,111 +1,27 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+`myo_sim` is a packaged library of MuJoCo musculoskeletal XML model definitions used by [MyoSuite](https://github.com/facebookresearch/myoSuite).
 
-## Overview
+Read `docs/wiki/index.md` before making any substantial change.
 
-`myo_sim` is a packaged library of MuJoCo musculoskeletal (MSK) XML model definitions used by [MyoSuite](https://github.com/facebookresearch/myoSuite). The primary artifacts are `.xml` model files and referenced assets under `myo_sim/models/`, plus Python helpers for registry lookup and MjSpec composition.
-
-## Running Tests
+## Quickstart
 
 ```bash
-# Run the full model-loading smoke test
-uv run pytest test_sims.py
+# Install
+uv sync
 
-# Run a single test class
-uv run pytest test_sims.py::TestSims::test_sims
+# Run tests
+uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py
 
-# Run a muscle-symmetry analysis script (not pytest — runs as a standalone script)
+# Compose a bilateral model
+uv run python -m myo_sim.build.compose --model myoarms
+
+# Run a muscle-symmetry analysis script (standalone, not pytest)
 cd tests && uv run python debug_muscle_leg.py
 cd tests && uv run python debug_muscle_torso.py
 cd tests && uv run python debug_muscle_bimanual.py
 ```
 
-Requires `mujoco` and `numpy` (plus `matplotlib` for analysis plots). Package metadata lives in `pyproject.toml`.
+## More detail
 
-## Repository Structure
-
-```
-myo_sim/              # Installable Python package
-  models/             # Packaged XML model tree and assets
-    <model>/          # One directory per body segment / assembly
-      <model>.xml     # Top-level MuJoCo model (entry point)
-      assets/         # Sub-XMLs included via <include> or <compiler meshdir>
-        *_assets.xml  # Mesh/texture/material declarations
-        *_chain.xml   # Kinematic chain (bodies, joints, geoms)
-    meshes/           # Shared .stl mesh files
-    scene/            # Scene wrapper XMLs
-    contacts/         # Shared contact-pair XMLs for MjSpec composition
-  build/              # MjSpec composition helpers and model registry
-tests/                # Muscle analysis scripts + utilities
-test_sims.py          # Pytest smoke test: loads every model via mujoco.MjModel
-```
-
-Key packaged model directories include `arm`, `leg`, `torso`, `head`, `body`, `contacts`, `meshes`, `scene`, and `textures`.
-
-## Model Architecture
-
-Models are composed via MuJoCo's `<include>` and `<compiler meshdir>` mechanisms:
-
-- **Assets XMLs** (`*_assets.xml`) declare meshes, materials, tendons.
-- **Body/Chain XMLs** (`*_body.xml`, `*_chain.xml`) define the kinematic tree, joints, muscles, and contact geometries.
-- **Top-level XMLs** define directly loadable static models where a part is self-contained; torso-dependent parts are composed through `myo_sim/build/compose.py`.
-- **MjSpec models** compose mirrored arms, legs, contacts, and full-body variants in `myo_sim/build/compose.py`.
-
-All meshes live in `myo_sim/models/meshes/` and are shared across models. `scene/` XMLs wrap individual models with environment assets for rendering.
-
-## Design Principles (issue #75)
-
-The architecture separates concerns into four layers, implemented through file-naming conventions within `myo_sim/models/<part>/assets/` and the `myo_sim/build/` package:
-
-1. **Kinematics** (`*_chain.xml`) — immutable skeleton: bodies, joints, and global structural sites. Defined once per body part; never duplicated across assemblies.
-2. **Actuation** (`*_muscle.xml`, `*_tendon.xml`) — body-part-local actuation: muscles, tendons, wrapping surfaces, equality constraints, and local via/wrapping sites.
-3. **Assets** (`*_assets.xml`) — mesh, material, and texture declarations shared within a body part.
-4. **Build** (`myo_sim/build/compose.py`) — deterministic composition pipeline that assembles chains, actuation, and contacts into full models using MjSpec.
-
-When adding or editing model elements, respect this separation: structural geometry belongs in chain files, actuation belongs in muscle/tendon files, and cross-part composition is handled in `myo_sim/build/`.
-
-## Naming Conventions
-
-- Body parts use the `Myo` prefix (e.g., `MyoLeg`, `MyoArm`).
-- Bilateral structures use `_r` / `_l` suffixes (right / left) for joints, muscles, bodies, and sites.
-- Muscles follow OpenSim naming (e.g., `gaslat_r`, `psoas_l`).
-- Sites used for attachment/endpoint markers are placed in group 3 (inactive by default).
-
-## Muscle Analysis Utilities (`tests/muscle_analysis_utils.py`)
-
-Provides helpers for validating MSK model quality:
-- `compute_moment_arm_curve` / `compute_force_length_curve` — sweep joint angles and record muscle properties.
-- `parse_model_joint_equalities` / `apply_eq_constraints` — resolve MuJoCo joint equality constraints (polynomial coupling between joints) before computing forward kinematics.
-- `plot_pair` — compare left/right muscle pairs visually.
-
-Analysis scripts output plots to `tests/output/muscle_analysis/`.
-
-## Model Conversion Pipeline
-
-Models are converted from OpenSim (`.osim`) format via a three-step pipeline (not in this repo):
-1. Basic element conversion (bones, joints, muscle paths, wrapping objects)
-2. Moment arm optimization (wrapping geometry tuning)
-3. Muscle force optimization (force-length parameter fitting)
-
-Post-conversion manual adjustments are documented in each model's `README.md`.
-
-## Development Workflow
-
-- Always use `uv run`, not `python`.
-- Always run `uv run pytest -n 8` before creating a PR.
-- Run `uv run pre-commit install` after cloning to enable pre-commit hooks (ruff, uv-lock, kernel-analyzer).
-- Prefer running individual tests rather than the full test suite to improve iteration speed.
-
-## Commits and PRs
-
-- PR body should be plain, concise prose. Describe the problem, what the change does, and any non-obvious tradeoffs. Bullet points listing changes are fine, but avoid section headers, structured templates, and emojis.
-- PR and commit messages are rendered on GitHub, so don't hard-wrap them at 88 columns. Let each sentence flow on one line.
-- Push branches to your own fork, not to the MyoHub/myo_sim repo directly.
-- Amending commits is fine before a PR has reviewers looking at it. Once a PR is under review, use new commits so reviewers can see what changed.
-- When responding to PR review comments: reply to each comment individually confirming what you did (or why you didn't), resolve addressed threads, and add a summary comment on the PR covering what was applied and what was intentionally skipped.
-
-## Code Style
-
-- Line length limit is 128 characters. Docstring length limit is 100 characters.
-- Prefer targeted, efficient tests over exhaustive edge-case coverage.
+Everything else — model architecture, file-naming conventions, XML standards, Python style, PR rules, naming conventions, build/composition pipeline, and muscle analysis utilities — is documented in `docs/wiki/`. Start with `docs/wiki/index.md`.

--- a/docs/wiki/engineering-standards.md
+++ b/docs/wiki/engineering-standards.md
@@ -19,6 +19,15 @@ These rules apply to every change in this repository.
 
 **Numeric formatting.** Preserve existing numeric formatting unless the value itself is part of an intentional edit.
 
+**Multi-part composition (MuJoCo ≥ 3.8).** MuJoCo 3.8 rejects a compiled model that contains two default class names with the same identifier, whether from the top-level `class="main"` or from any nested `<default class="...">`. Two issues arise when `myotorso_assets.xml` and `myoarm_r_assets.xml` are combined via static `<include>`:
+
+1. Both declare `<default class="main">` — the top-level required name, which cannot be renamed.
+2. Both declare `<default class="wrap">` and `<default class="marker">` — duplicate nested class names.
+
+Either collision alone is enough for MuJoCo 3.8 to raise `"repeated default class name"`.
+
+**Rule:** never write a static top-level XML that combines `myotorso_assets.xml` with `myoarm_r_assets.xml`. More generally, when adding a new `*_assets.xml`, ensure its class names do not collide with those of any other asset file it could be included alongside. Asset files with bare `<default>` and no `class="main"` (`leg/assets/myolegs_assets.xml`, `torso/assets/myotorso_abdomen_assets.xml`, `head/assets/myohead_simple_assets.xml`) are safe to combine. Multi-part assemblies must use `build_model()` in `myo_sim/build/compose.py`, which uses MjSpec attachment with independent per-child namespaces. All current standalone XMLs comply.
+
 ## Python
 
 - Always use `uv run`, never bare `python`.

--- a/docs/wiki/engineering-standards.md
+++ b/docs/wiki/engineering-standards.md
@@ -23,7 +23,7 @@ These rules apply to every change in this repository.
 
 **Naming rule for `*_assets.xml` files:** all nested default class names must be scoped to the body part — never use generic names like `wrap` or `marker`. Use `myotorso_wrap`, `myoarm_wrap`, `myotorso_marker`, `myoarm_marker`, etc. The leg assets already follow this (`myoleg_wrap`, `myo_leg_marker`).
 
-**Composition rule:** never write a static top-level XML that includes two or more `*_assets.xml` files that each declare `<default class="main">`. Multi-part assemblies must use `build_model()` in `myo_sim/build/compose.py`, which uses MjSpec attachment with independent per-child namespaces and is not affected by class name collisions. Asset files with bare `<default>` (no `class="main"`) are safe to combine: `leg/assets/myolegs_assets.xml`, `torso/assets/myotorso_abdomen_assets.xml`, `head/assets/myohead_simple_assets.xml`.
+**Composition rule:** multi-part assemblies must use `build_model()` in `myo_sim/build/compose.py`, which uses MjSpec attachment with independent per-child namespaces and sidesteps class name collisions entirely. Sharing `class="main"` across two included files is accepted by MuJoCo 3.8 — it is the nested sub-class names (e.g. `wrap`, `marker`) that must be unique. The naming rule above ensures this.
 
 ## Python
 

--- a/docs/wiki/engineering-standards.md
+++ b/docs/wiki/engineering-standards.md
@@ -19,14 +19,11 @@ These rules apply to every change in this repository.
 
 **Numeric formatting.** Preserve existing numeric formatting unless the value itself is part of an intentional edit.
 
-**Multi-part composition (MuJoCo ≥ 3.8).** MuJoCo 3.8 rejects a compiled model that contains two default class names with the same identifier, whether from the top-level `class="main"` or from any nested `<default class="...">`. Two issues arise when `myotorso_assets.xml` and `myoarm_r_assets.xml` are combined via static `<include>`:
+**Multi-part composition (MuJoCo ≥ 3.8).** MuJoCo 3.8 rejects a compiled model where two included files declare a default class with the same name. The name `"main"` is required for the top-level default and cannot be renamed.
 
-1. Both declare `<default class="main">` — the top-level required name, which cannot be renamed.
-2. Both declare `<default class="wrap">` and `<default class="marker">` — duplicate nested class names.
+**Naming rule for `*_assets.xml` files:** all nested default class names must be scoped to the body part — never use generic names like `wrap` or `marker`. Use `myotorso_wrap`, `myoarm_wrap`, `myotorso_marker`, `myoarm_marker`, etc. The leg assets already follow this (`myoleg_wrap`, `myo_leg_marker`).
 
-Either collision alone is enough for MuJoCo 3.8 to raise `"repeated default class name"`.
-
-**Rule:** never write a static top-level XML that combines `myotorso_assets.xml` with `myoarm_r_assets.xml`. More generally, when adding a new `*_assets.xml`, ensure its class names do not collide with those of any other asset file it could be included alongside. Asset files with bare `<default>` and no `class="main"` (`leg/assets/myolegs_assets.xml`, `torso/assets/myotorso_abdomen_assets.xml`, `head/assets/myohead_simple_assets.xml`) are safe to combine. Multi-part assemblies must use `build_model()` in `myo_sim/build/compose.py`, which uses MjSpec attachment with independent per-child namespaces. All current standalone XMLs comply.
+**Composition rule:** never write a static top-level XML that includes two or more `*_assets.xml` files that each declare `<default class="main">`. Multi-part assemblies must use `build_model()` in `myo_sim/build/compose.py`, which uses MjSpec attachment with independent per-child namespaces and is not affected by class name collisions. Asset files with bare `<default>` (no `class="main"`) are safe to combine: `leg/assets/myolegs_assets.xml`, `torso/assets/myotorso_abdomen_assets.xml`, `head/assets/myohead_simple_assets.xml`.
 
 ## Python
 

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -42,7 +42,7 @@ def get_xml_path(name: str) -> Path:
     return MODELS_DIR / REGISTRY[name]
 
 
-def load(name: str):
+def load(name: str) -> tuple:
     """Load a MuJoCo model by registry name. Returns (MjModel, MjData)."""
     import mujoco
 

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -161,13 +161,13 @@ MODEL_REGISTRY = {
 }
 
 
-def pair_is_supported(pair, include_left_arm_contacts: bool):
+def pair_is_supported(pair: dict, include_left_arm_contacts: bool) -> bool:
     if include_left_arm_contacts:
         return True
     return not (pair.get("geom1", "").endswith("_l") or pair.get("geom2", "").endswith("_l"))
 
 
-def load_torso_spec(registration: ModelRegistration):
+def load_torso_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     """Load the single-torso model and make it match the bimanual root pose."""
     torso = mujoco.MjSpec.from_file(str(TORSO_XML))
     torso.compiler.balanceinertia = True
@@ -190,7 +190,7 @@ def load_torso_spec(registration: ModelRegistration):
     return torso
 
 
-def make_torso_passive(torso: mujoco.MjSpec):
+def make_torso_passive(torso: mujoco.MjSpec) -> None:
     """Remove torso dynamics so the anatomical torso acts as a fixed scaffold."""
     for equality in list(torso.equalities):
         torso.delete(equality)
@@ -203,13 +203,13 @@ def make_torso_passive(torso: mujoco.MjSpec):
     return torso
 
 
-def load_passive_torso_spec(registration: ModelRegistration):
+def load_passive_torso_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_torso_spec(registration)
     make_torso_passive(torso)
     return torso
 
 
-def load_right_arm_spec():
+def load_right_arm_spec() -> mujoco.MjSpec:
     right_arm_xml = build_child_xml_from_components(
         model_name="myoarm_r_attach",
         compiler_meshdir=ROOT,
@@ -225,7 +225,7 @@ def load_right_arm_spec():
     return right_arm
 
 
-def build_mirrored_left_arm_xml(mirror_rules: MirrorRules):
+def build_mirrored_left_arm_xml(mirror_rules: MirrorRules) -> str:
     """Build a left-arm MJCF child by mirroring the right-arm XML in memory."""
     return build_mirrored_child_xml(
         model_name="myoarm_l_mirrored_from_r",
@@ -240,13 +240,13 @@ def build_mirrored_left_arm_xml(mirror_rules: MirrorRules):
     )
 
 
-def load_mirrored_left_arm_spec(mirror_rules: MirrorRules):
+def load_mirrored_left_arm_spec(mirror_rules: MirrorRules) -> mujoco.MjSpec:
     left_arm = mujoco.MjSpec.from_string(build_mirrored_left_arm_xml(mirror_rules))
     left_arm.compiler.balanceinertia = True
     return left_arm
 
 
-def load_legs_spec():
+def load_legs_spec() -> mujoco.MjSpec:
     legs_xml = build_child_xml_from_components(
         model_name="myolegs_attach",
         compiler_meshdir=ROOT,
@@ -262,7 +262,7 @@ def load_legs_spec():
     return legs
 
 
-def build_arms_body_model(registration: ModelRegistration):
+def build_arms_body_model(registration: ModelRegistration) -> mujoco.MjModel:
     torso = load_passive_torso_spec(registration)
     attach_to_site(
         torso,
@@ -279,7 +279,7 @@ def build_arms_body_model(registration: ModelRegistration):
     return torso.compile()
 
 
-def build_right_arm_body_model(registration: ModelRegistration):
+def build_right_arm_body_model(registration: ModelRegistration) -> mujoco.MjModel:
     torso = load_passive_torso_spec(registration)
     attach_to_site(
         torso,
@@ -290,7 +290,7 @@ def build_right_arm_body_model(registration: ModelRegistration):
     return torso.compile()
 
 
-def load_right_hand_from_arm_spec():
+def load_right_hand_from_arm_spec() -> mujoco.MjSpec:
     hand = load_right_arm_spec()
     hand.modelname = "myohand_r_from_myoarm_r"
     hand.compiler.balanceinertia = True
@@ -298,14 +298,14 @@ def load_right_hand_from_arm_spec():
     return hand
 
 
-def load_left_hand_from_arm_spec():
+def load_left_hand_from_arm_spec() -> mujoco.MjSpec:
     hand = load_mirrored_left_arm_spec(MirrorRules())
     hand.modelname = "myohand_l_from_mirrored_myoarm_r"
     prune_arm_spec_to_hand(hand, "l")
     return hand
 
 
-def build_right_hand_from_arm_model():
+def build_right_hand_from_arm_model() -> mujoco.MjModel:
     torso = load_passive_torso_spec(MODEL_REGISTRY["myohand_r"])
     attach_to_site(
         torso,
@@ -315,7 +315,7 @@ def build_right_hand_from_arm_model():
     return torso.compile()
 
 
-def build_both_hands_from_arm_model():
+def build_both_hands_from_arm_model() -> mujoco.MjModel:
     torso = load_passive_torso_spec(MODEL_REGISTRY["myohands"])
     attach_to_site(
         torso,
@@ -330,15 +330,15 @@ def build_both_hands_from_arm_model():
     return torso.compile()
 
 
-def build_right_hand_model(registration: ModelRegistration):
+def build_right_hand_model(registration: ModelRegistration) -> mujoco.MjModel:
     return build_right_hand_from_arm_model()
 
 
-def build_both_hands_model(registration: ModelRegistration):
+def build_both_hands_model(registration: ModelRegistration) -> mujoco.MjModel:
     return build_both_hands_from_arm_model()
 
 
-def load_left_arm_spec(registration: ModelRegistration):
+def load_left_arm_spec(registration: ModelRegistration) -> mujoco.MjSpec | None:
     if registration.left_arm_strategy == LEFT_ARM_STRATEGY_MIRROR_RIGHT:
         return load_mirrored_left_arm_spec(registration.mirror_rules)
     if registration.left_arm_strategy == LEFT_ARM_STRATEGY_NONE:
@@ -346,7 +346,7 @@ def load_left_arm_spec(registration: ModelRegistration):
     raise ValueError(f"Unknown left arm strategy for {registration.name}: {registration.left_arm_strategy}")
 
 
-def build_torso_arms_model(registration: ModelRegistration):
+def build_torso_arms_model(registration: ModelRegistration) -> mujoco.MjModel:
     torso = load_torso_spec(registration)
     right_arm = load_right_arm_spec()
     left_arm = load_left_arm_spec(registration)
@@ -358,7 +358,7 @@ def build_torso_arms_model(registration: ModelRegistration):
     return torso.compile()
 
 
-def build_fullbody_model(registration: ModelRegistration):
+def build_fullbody_model(registration: ModelRegistration) -> mujoco.MjModel:
     torso = load_torso_spec(registration)
     attach_to_site(torso, load_right_arm_spec(), find_site(torso, RIGHT_ARM_ATTACH_SITE))
     left_arm = load_left_arm_spec(registration)
@@ -372,7 +372,7 @@ def build_fullbody_model(registration: ModelRegistration):
     return torso.compile()
 
 
-def build_legs_abdomen_model(registration: ModelRegistration):
+def build_legs_abdomen_model(registration: ModelRegistration) -> mujoco.MjModel:
     abdomen = mujoco.MjSpec.from_file(str(TORSO_ABDOMEN_XML))
     abdomen.compiler.balanceinertia = True
 
@@ -395,11 +395,11 @@ BUILDERS = {
 }
 
 
-def build_registered_model(registration: ModelRegistration):
+def build_registered_model(registration: ModelRegistration) -> mujoco.MjModel:
     return BUILDERS[registration.build_strategy](registration)
 
 
-def build_model(model_name: str):
+def build_model(model_name: str) -> mujoco.MjModel:
     try:
         registration = MODEL_REGISTRY[model_name]
     except KeyError as exc:
@@ -408,7 +408,7 @@ def build_model(model_name: str):
     return build_registered_model(registration)
 
 
-def view_model(model):
+def view_model(model: mujoco.MjModel) -> None:
     import mujoco.viewer
 
     data = mujoco.MjData(model)
@@ -429,7 +429,7 @@ def view_model(model):
             time.sleep(model.opt.timestep)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model",

--- a/myo_sim/build/hand.py
+++ b/myo_sim/build/hand.py
@@ -68,12 +68,12 @@ RIGHT_HAND_REMOVED_JOINTS = frozenset(
 )
 
 
-def add_side_suffix(name: str, side: str):
+def add_side_suffix(name: str, side: str) -> str:
     suffix = f"_{side}"
     return name if name.endswith(suffix) else f"{name}{suffix}"
 
 
-def side_name(name: str, side: str):
+def side_name(name: str, side: str) -> str:
     if side == "r":
         return name
     if name.endswith("_r"):
@@ -81,12 +81,12 @@ def side_name(name: str, side: str):
     return name
 
 
-def base_actuator_name(name: str, side: str):
+def base_actuator_name(name: str, side: str) -> str:
     suffix = f"_{side}"
     return name[: -len(suffix)] if name.endswith(suffix) else name
 
 
-def tendon_wrap_geom_names(spec):
+def tendon_wrap_geom_names(spec: object) -> set[str]:
     geom_names = set()
     for tendon in spec.tendons:
         for index in range(len(tendon.path)):
@@ -96,7 +96,7 @@ def tendon_wrap_geom_names(spec):
     return geom_names
 
 
-def prune_arm_spec_to_hand(spec, side: str):
+def prune_arm_spec_to_hand(spec: object, side: str) -> None:
     """Remove proximal arm dynamics from an arm spec, leaving wrist/hand controls."""
     removed_joints = {side_name(name, side) for name in RIGHT_HAND_REMOVED_JOINTS}
 

--- a/myo_sim/build/utils.py
+++ b/myo_sim/build/utils.py
@@ -36,7 +36,7 @@ class MirrorRules:
     mirror_file_attributes: bool = False
 
 
-def find_body(spec, body_name: str):
+def find_body(spec: object, body_name: str) -> object:
     """Find a body across MuJoCo Python API variants."""
     if hasattr(spec, "find_body"):
         body = spec.find_body(body_name)
@@ -53,7 +53,7 @@ def find_body(spec, body_name: str):
     return body
 
 
-def find_site(spec, site_name: str):
+def find_site(spec: object, site_name: str) -> object:
     """Find a site across MuJoCo Python API variants."""
     if hasattr(spec, "find_site"):
         site = spec.find_site(site_name)
@@ -70,25 +70,25 @@ def find_site(spec, site_name: str):
     return site
 
 
-def attach_to_site(parent_spec, child_spec, parent_site):
+def attach_to_site(parent_spec: object, child_spec: object, parent_site: object) -> None:
     """Attach child spec at a parent attachment site."""
     parent_spec.attach(child_spec, prefix="", suffix="", site=parent_site)
 
 
-def attach_to_frame(parent_spec, child_spec, parent_frame):
+def attach_to_frame(parent_spec: object, child_spec: object, parent_frame: object) -> None:
     """Attach child spec at a parent frame."""
     parent_spec.attach(child_spec, prefix="", suffix="", frame=parent_frame)
 
 
-def float_list(value: str):
+def float_list(value: str) -> list[float]:
     return [float(item) for item in value.split()]
 
 
-def format_floats(values):
+def format_floats(values: list[float]) -> str:
     return " ".join(f"{value:.12g}" for value in values)
 
 
-def rename_material(spec, old_name: str, new_name: str):
+def rename_material(spec: object, old_name: str, new_name: str) -> None:
     """Avoid shared material-name collisions across attached specs."""
     try:
         material = spec.material(old_name)
@@ -99,7 +99,7 @@ def rename_material(spec, old_name: str, new_name: str):
     material.name = new_name
 
 
-def add_contact_pairs(spec, contacts_xml: Path, include_pair=None):
+def add_contact_pairs(spec: object, contacts_xml: Path, include_pair: object = None) -> None:
     """Add contact pairs from an MJCF include file."""
     for pair in ET.parse(contacts_xml).getroot().iter("pair"):
         if include_pair is not None and not include_pair(pair):
@@ -118,7 +118,7 @@ def add_contact_pairs(spec, contacts_xml: Path, include_pair=None):
         )
 
 
-def mirror_name(value: str, rules: MirrorRules):
+def mirror_name(value: str, rules: MirrorRules) -> str:
     if value in rules.common_names:
         return value
     for old, new in rules.replacements:
@@ -134,7 +134,7 @@ def mirror_name(value: str, rules: MirrorRules):
     return f"{value}_l"
 
 
-def should_mirror_class_name(value: str, rules: MirrorRules):
+def should_mirror_class_name(value: str, rules: MirrorRules) -> bool:
     if value.endswith("_r"):
         return True
     if any(old in value for old, _ in rules.replacements):
@@ -142,7 +142,7 @@ def should_mirror_class_name(value: str, rules: MirrorRules):
     return any(value.startswith(old) for old, _ in rules.prefix_replacements)
 
 
-def mirror_reference(element, attr_name: str, attr_value: str, rules: MirrorRules):
+def mirror_reference(element: ET.Element, attr_name: str, attr_value: str, rules: MirrorRules) -> str:
     mirrored = mirror_name(attr_value, rules)
     should_lowercase_geom = (attr_name == "name" and element.tag == "geom") or (attr_name == "geom")
     if should_lowercase_geom:
@@ -152,7 +152,7 @@ def mirror_reference(element, attr_name: str, attr_value: str, rules: MirrorRule
     return mirrored
 
 
-def mirror_xyz_attribute(element, attr_name: str, rules: MirrorRules):
+def mirror_xyz_attribute(element: ET.Element, attr_name: str, rules: MirrorRules) -> None:
     values = float_list(element.get(attr_name))
     if len(values) != 3:
         return
@@ -164,7 +164,7 @@ def mirror_xyz_attribute(element, attr_name: str, rules: MirrorRules):
     element.set(attr_name, format_floats(values))
 
 
-def mirror_axial_attribute(element, attr_name: str):
+def mirror_axial_attribute(element: ET.Element, attr_name: str) -> None:
     values = float_list(element.get(attr_name))
     if len(values) != 3:
         return
@@ -173,7 +173,7 @@ def mirror_axial_attribute(element, attr_name: str):
     element.set(attr_name, format_floats(values))
 
 
-def mirror_quaternion(element):
+def mirror_quaternion(element: ET.Element) -> None:
     values = float_list(element.get("quat"))
     if len(values) != 4:
         return
@@ -182,7 +182,7 @@ def mirror_quaternion(element):
     element.set("quat", format_floats(values))
 
 
-def mirror_fromto(element):
+def mirror_fromto(element: ET.Element) -> None:
     values = float_list(element.get("fromto"))
     if len(values) != 6:
         return
@@ -191,7 +191,7 @@ def mirror_fromto(element):
     element.set("fromto", format_floats(values))
 
 
-def mirror_fullinertia(element):
+def mirror_fullinertia(element: ET.Element) -> None:
     values = float_list(element.get("fullinertia"))
     if len(values) != 6:
         return
@@ -201,7 +201,7 @@ def mirror_fullinertia(element):
     element.set("fullinertia", format_floats(values))
 
 
-def mirror_element(element, rules: MirrorRules):
+def mirror_element(element: ET.Element, rules: MirrorRules) -> ET.Element:
     mirrored = copy.deepcopy(element)
     for child in list(mirrored):
         index = list(mirrored).index(child)
@@ -251,8 +251,8 @@ def build_mirrored_child_xml(
     source_chain_xml: Path,
     root_body_name: str,
     root_site_name: str,
-    rules=None,
-):
+    rules: MirrorRules | None = None,
+) -> str:
     """Build a mirrored MJCF child XML from right-side arm component files."""
     if rules is None:
         rules = MirrorRules()
@@ -301,7 +301,7 @@ def build_child_xml_from_components(
     chain_xml: Path,
     root_body_name: str,
     root_site_name: str,
-):
+) -> str:
     """Build a standalone child XML from asset/tendon/muscle/chain includes."""
     root = ET.Element("mujoco", {"model": model_name})
     ET.SubElement(

--- a/myo_sim/models/arm/assets/myoarm_r_assets.xml
+++ b/myo_sim/models/arm/assets/myoarm_r_assets.xml
@@ -28,10 +28,10 @@
             <default class="myoarm_coll">
                 <geom type="capsule" group="4" contype="1" conaffinity="0" condim="3" rgba="0.8 0.7 .5 .8" margin="0.001" material="MatSkin"/>
             </default>
-            <default class="wrap">
+            <default class="myoarm_wrap">
                 <geom group="3" rgba="0.19 0.83 0.78 0.2"/>
             </default>
-            <default class="marker">
+            <default class="myoarm_marker">
                  <site rgba="1 0.1 0.5 0.5" size="0.001" group="4"/>
             </default>
         </default>

--- a/myo_sim/models/arm/assets/myoarm_r_chain.xml
+++ b/myo_sim/models/arm/assets/myoarm_r_chain.xml
@@ -15,7 +15,7 @@
         <site name="DELT1_DELT1-P4_r" pos="-0.014 0.01106 0.08021"/>
         <site name="PECM1_PECM1-P3_r" pos="0.0264476 0.004005 0.057232"/>
         <site name="PECM1_PECM1-P4_r" pos="0.00321 -0.00013 0.05113"/>
-        <site class="marker" name="Clavicle_marker_r" pos="0.01835 -0.00464 -0.00046"/>
+        <site class="myoarm_marker" name="Clavicle_marker_r" pos="0.01835 -0.00464 -0.00046"/>
 
         <body name="clavphant_r" pos="-0.01433 0.02007 0.1355">
             <inertial diaginertia="1 1 1" mass="0.001" pos="0 0 0"/>
@@ -27,12 +27,12 @@
                 <joint axis="-0.754084 0.297594 0.585487" name="acromioclavicular_r3_r" pos="0 0 0" range="0.0 1.228"/>
                 <joint axis="0.6377 0.1186 0.7611" name="acromioclavicular_r1_r" pos="0 0 0" range="0.0 0.552"/>
                 <geom mesh="scapula_r" name="scapula_r" type="mesh"/>
-                <geom class="wrap" name="Deltoid2_ellipsoid" pos="-0.0058 -0.0378 0.0096" quat="-0.423842 0.568442 0.433325 -0.556293" size="0.033"/>
-                <geom class="wrap" name="Delt3_torus" pos="-0.0973 -0.0428 -0.037" quat="0.916494 0.246518 0.233162 -0.211903" size="0.04"/>
-                <geom class="wrap" name="INFSP_torus" pos="-0.0561 -0.0199 -0.0112" quat="0.953924 0.0340622 0.288198 0.0762223" size="0.008"/>
-                <geom class="wrap" name="TMIN_ellipsoid" pos="-0.0418 -0.0519 -0.0359" quat="0.407504 -0.492108 -0.706779 -0.3037" size="0.03"/>
-                <geom class="wrap" name="TRIlongglen_cylinder" pos="-0.0359 -0.0309 -0.0132" quat="0.351544 0.110456 -0.628265 0.685201" size="0.003 0.015" type="cylinder"/>
-                <geom class="wrap" name="Deltoid2_ellipsoid_DELT2" pos="-0.0122268 -0.0345692 0.0127541" quat="-0.423842 0.568442 0.433325 -0.556293" size="0.0297339"/>
+                <geom class="myoarm_wrap" name="Deltoid2_ellipsoid" pos="-0.0058 -0.0378 0.0096" quat="-0.423842 0.568442 0.433325 -0.556293" size="0.033"/>
+                <geom class="myoarm_wrap" name="Delt3_torus" pos="-0.0973 -0.0428 -0.037" quat="0.916494 0.246518 0.233162 -0.211903" size="0.04"/>
+                <geom class="myoarm_wrap" name="INFSP_torus" pos="-0.0561 -0.0199 -0.0112" quat="0.953924 0.0340622 0.288198 0.0762223" size="0.008"/>
+                <geom class="myoarm_wrap" name="TMIN_ellipsoid" pos="-0.0418 -0.0519 -0.0359" quat="0.407504 -0.492108 -0.706779 -0.3037" size="0.03"/>
+                <geom class="myoarm_wrap" name="TRIlongglen_cylinder" pos="-0.0359 -0.0309 -0.0132" quat="0.351544 0.110456 -0.628265 0.685201" size="0.003 0.015" type="cylinder"/>
+                <geom class="myoarm_wrap" name="Deltoid2_ellipsoid_DELT2" pos="-0.0122268 -0.0345692 0.0127541" quat="-0.423842 0.568442 0.433325 -0.556293" size="0.0297339"/>
                 <site name="Deltoid2_sidesite_r" pos="-0.006523 -0.02881 0.04238"/>
                 <site name="Delt3_sidesite_r" pos="-0.0973 -0.0428 -0.037"/>
                 <site name="INFSP_sidesite_r" pos="-0.0561 -0.0199 -0.0112"/>
@@ -69,7 +69,7 @@
                 <site name="BIClong_BIClong-P2_r" pos="-0.02094 -0.01309 -0.00461"/>
                 <site name="BICshort_BICshort-P1_r" pos="0.01268 -0.03931 -0.02625"/>
                 <site name="BICshort_BICshort-P2_r" pos="0.00093 -0.06704 -0.01593"/>
-                <site class="marker" name="Shoulder_marker_r" pos="0.0014 -0.00147 0.01369"/>
+                <site class="myoarm_marker" name="Shoulder_marker_r" pos="0.0014 -0.00147 0.01369"/>
                 <body name="scapphant_r" pos="-0.00955 -0.034 0.009">
                     <inertial diaginertia="1 1 1" mass="0.001" pos="0 0 0"/>
                     <joint axis="0.6377 0.1186 0.7611" name="unrothum_r1_r" pos="0 0 0" range="-0.552 -0.0"/>
@@ -87,8 +87,8 @@
                                 <joint axis="0.00479995 0.999089 0.0423995" name="shoulder_rot_r" pos="0 0 0" range="-1.571 2.094"/>
                                 <geom name="humerus_r" mesh="humerus_r" type="mesh"/>
                                 <geom name="humerus_coll_r" type="capsule" class="myoarm_coll" size="0.042 0.140" pos="0 -.13 0" euler="1.57079632679 0 0"/>
-                                <geom name="Elbow_PT_ECRL_wrap" type="sphere" size="0.027" pos="-0.005 -0.3 0.005" class="wrap"/>
-                                <geom name="Elbow_PT_FCU_wrap" type="sphere" size="0.015" pos="-0.005 -0.29 -0.053" class="wrap"/>
+                                <geom name="Elbow_PT_ECRL_wrap" type="sphere" size="0.027" pos="-0.005 -0.3 0.005" class="myoarm_wrap"/>
+                                <geom name="Elbow_PT_FCU_wrap" type="sphere" size="0.015" pos="-0.005 -0.29 -0.053" class="myoarm_wrap"/>
                                 <site name="Elbow_PT_ECRL_site_ECRL_side_r" pos="0.03 -0.2872 0.04"/>
                                 <site name="Elbow_PT_FCU_site_FCU_side_r" pos="0.03 -0.2872 -0.04"/>
 
@@ -107,49 +107,49 @@
                                 <site name="EDC2-P1_r" pos="0.0006 -0.289 0.0187"/>
                                 <site name="EDM-P1_r" pos="0.0009 -0.2892 0.0185"/>
 
-                                <geom class="wrap" name="DELT1hh_ellipsoid" pos="-0.0139 -0.0127 -0.0262" quat="0.83666 0.160028 0.454758 0.259973" size="0.03"/>
-                                <geom class="wrap" name="delt2hum_cylinder" pos="0.0017 -0.0958 0.0011" quat="0.713926 0.699514 -0.0280022 0.014313" size="0.0109 0.12" type="cylinder"/>
-                                <geom class="wrap" name="delt3hum_ellipsoid" pos="0.0019 -0.0592 0.0011" quat="0.156827 0.126209 0.749421 -0.630749" size="0.01"/>
-                                <geom class="wrap" name="SUPSP_ellipsoid" pos="0.0002 0.0077 0.0043" quat="0.793859 0.0125049 0.0149602 -0.607789" size="0.02"/>
-                                <geom class="wrap" name="INFSP_and_TMIN_hum_head_ellipsoid" pos="-0.0003 0.0026 0.0038" quat="0.989183 -0.142571 -0.00937337 -0.0332047" size="0.02" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="infsp_new_cylinder" pos="-0.0019 -0.019 0.0069" quat="0.634204 0.685268 0.103666 -0.342703" size="0.0235 0.0575" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="SUBSCAP_ellipsoid" pos="-0.0025 0.0007 -0.0045" quat="0.881836 -0.408886 0.210176 0.104899" size="0.017"/>
-                                <geom class="wrap" name="LIGhh_s_ellipsoid" pos="-0.001 0.003 0.003" quat="0.923956 -0.382499 0 0" size="0.02"/>
-                                <geom class="wrap" name="LIGhh_mi_ellipsoid" pos="-0.001 0.004 0.001" quat="0.923956 -0.382499 0 0" size="0.019"/>
-                                <geom class="wrap" name="TMINhum_cylinder" pos="0.003 -0.0255 0.0013" quat="-0.0348606 -0.0161876 -0.671884 0.739658" size="0.022 0.0565" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="TMAJ_LAThum_cylinder" pos="0.0007 -0.0443 -0.0055" quat="0.560987 0.513042 -0.468432 0.45017" size="0.007 0.02" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="PEC12hum_cylinder" pos="0.002 -0.0508 -0.0017" quat="0.623759 0.640765 0.289032 -0.341767" size="0.009 0.035" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="PEC23hh_sphere" pos="-0.0086 0.0021 -0.0004" size="0.02" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="PEC1hh_ellipsoid" pos="-0.0037 0.0005 -0.0025" quat="0.916754 -0.32328 -0.0902682 0.216573" size="0.02"/>
-                                <geom class="wrap" name="PEC3hum_cylinder" pos="0.0009 -0.0551 -0.0004" quat="0.495166 0.406012 -0.520135 0.565176" size="0.008 0.05" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="LAT_TMAJhh_cylinder" pos="-0.0224 0.0102 0.0094" quat="0.931143 -0.140037 -0.0596766 -0.331362" size="0.007 0.0225" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="LAT_TMAJ2hh_sphere" pos="-0.0016 0.0092 0.0052" quat="0.988522 -0.0615953 0.137948 0.0010005" size="0.03" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="Elbow_BIC_BRD_ellipsoid" pos="0.0019 -0.289 -0.014" quat="0.995526 -0.0630434 0.0695304 0.0108779" size="0.015"/>
-                                <geom class="wrap" name="TRIlonghh_ellipsoid" pos="-0.0078 -0.0041 -0.0014" quat="0.414166 0.226558 -0.879857 -0.0546691" size="0.02"/>
-                                <geom class="wrap" name="TRI_cylinder" pos="0.0028 -0.2919 -0.4219" quat="0.994531 -0.0700249 0.0022946 0.0774514" size="0.016 0.05" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="ANC_ellipsoid" pos="0.0134 -0.2861 -0.0008" quat="0.86157 -0.0459397 -0.0868616 0.498038" size="0.02"/>
-                                <geom class="wrap" name="BIClong_ellipsoid" pos="0.0033 0.005 0.0003" quat="0.227685 -0.774064 0.117793 0.578886" size="0.02"/>
-                                <geom class="wrap" name="TMAJ_LAT_PEC_CORBhh_sphere" pos="0.0007 0.035 0.006" size="0.03" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="DELT_TMAJ_LAT_PEC_CORBhh_sphere" pos="0.0007 0 0.006" size="0.03"/>
-                                <geom class="wrap" name="CORBhum_cylinder" pos="0.0027 -0.1202 -0.0059" quat="0.642357 -0.637406 0.335002 0.262422" size="0.008 0.05" type="cylinder" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="Elbow_PT_ECRL_ellipsoid" pos="0.003 -0.2872 -0.0069" quat="0.947273 -0.0932693 -0.0283097 0.305242" size="0.018"/>
-                                <geom class="wrap" name="LIGhh_s_ellipsoid_s_glenohum" pos="-0.001 0.003 0.003" quat="0.923956 -0.382499 0 0" size="0.02"/>
-                                <geom class="wrap" name="LIGhh_mi_ellipsoid_m_glenohum" pos="-0.001 0.004 0.001" quat="0.923956 -0.382499 0 0" size="0.019"/>
-                                <geom class="wrap" name="LIGhh_mi_ellipsoid_i_glenohum" pos="-0.001 0.004 0.001" quat="0.923956 -0.382499 0 0" size="0.019"/>
-                                <geom class="wrap" name="LIGhh_s_ellipsoid_coracohum" pos="-0.001 0.003 0.003" quat="0.923956 -0.382499 0 0" size="0.02"/>
-                                <geom class="wrap" name="DELT1hh_ellipsoid_DELT1" pos="-0.0179974 -0.0075035 -0.0580664" quat="0.83666 0.160028 0.454758 0.259973" size="0.029726" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="delt3hum_ellipsoid_DELT3" pos="0.0044 -0.0624 0.00443794" quat="0.156827 0.126209 0.749421 -0.630749" size="0.0125"/>
-                                <geom class="wrap" name="SUPSP_ellipsoid_SUPSP" pos="0.00110546 0.00820496 0.00197985" quat="0.793859 0.0125049 0.0149602 -0.607789" size="0.0202151"/>
-                                <geom class="wrap" name="SUBSCAP_ellipsoid_SUBSC" pos="0.0028089 -0.00313613 -0.00633073" quat="0.881836 -0.408886 0.210176 0.104899" size="0.0171729"/>
-                                <geom class="wrap" name="INFSP_and_TMIN_hum_head_ellipsoid_TMIN" pos="-0.000927281 -0.000469167 0.00327226" quat="0.989183 -0.142571 -0.00937337 -0.0332047" size="0.025" rgba="1 0 0 0"/>
-                                <geom class="wrap" name="PEC1hh_ellipsoid_PECM1" pos="0.0013 -0.0038025 -0.00251178" quat="0.916754 -0.32328 -0.0902682 0.216573" size="0.0221545"/>
-                                <geom class="wrap" name="TRIlonghh_ellipsoid_TRIlong" pos="-0.00 -0.00 -0.00" quat="0.414166 0.226558 -0.879857 -0.0546691" size="0.02"/>
-                                <geom class="wrap" name="ANC_ellipsoid_ANC" pos="0.0121714 -0.288051 -0.00144365" quat="0.86157 -0.0459397 -0.0868616 0.498038" size="0.0180029"/>
-                                <geom class="wrap" name="Elbow_BIC_BRD_ellipsoid_BIClong" pos="0.00296577 -0.290569 -0.0201662" quat="0.995526 -0.0630434 0.0695304 0.0108779" size="0.0150371"/>
-                                <geom class="wrap" name="BIClong_ellipsoid_BIClong" pos="0.0033 0.0015 0.0015" quat="0.227685 -0.774064 0.117793 0.578886" size="0.02"/>
-                                <geom class="wrap" name="Elbow_BIC_BRD_ellipsoid_BICshort" pos="0.00286868 -0.290754 0.030545" quat="0.995526 -0.0630434 0.0695304 0.0108779" size="0.0162859"/>
+                                <geom class="myoarm_wrap" name="DELT1hh_ellipsoid" pos="-0.0139 -0.0127 -0.0262" quat="0.83666 0.160028 0.454758 0.259973" size="0.03"/>
+                                <geom class="myoarm_wrap" name="delt2hum_cylinder" pos="0.0017 -0.0958 0.0011" quat="0.713926 0.699514 -0.0280022 0.014313" size="0.0109 0.12" type="cylinder"/>
+                                <geom class="myoarm_wrap" name="delt3hum_ellipsoid" pos="0.0019 -0.0592 0.0011" quat="0.156827 0.126209 0.749421 -0.630749" size="0.01"/>
+                                <geom class="myoarm_wrap" name="SUPSP_ellipsoid" pos="0.0002 0.0077 0.0043" quat="0.793859 0.0125049 0.0149602 -0.607789" size="0.02"/>
+                                <geom class="myoarm_wrap" name="INFSP_and_TMIN_hum_head_ellipsoid" pos="-0.0003 0.0026 0.0038" quat="0.989183 -0.142571 -0.00937337 -0.0332047" size="0.02" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="infsp_new_cylinder" pos="-0.0019 -0.019 0.0069" quat="0.634204 0.685268 0.103666 -0.342703" size="0.0235 0.0575" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="SUBSCAP_ellipsoid" pos="-0.0025 0.0007 -0.0045" quat="0.881836 -0.408886 0.210176 0.104899" size="0.017"/>
+                                <geom class="myoarm_wrap" name="LIGhh_s_ellipsoid" pos="-0.001 0.003 0.003" quat="0.923956 -0.382499 0 0" size="0.02"/>
+                                <geom class="myoarm_wrap" name="LIGhh_mi_ellipsoid" pos="-0.001 0.004 0.001" quat="0.923956 -0.382499 0 0" size="0.019"/>
+                                <geom class="myoarm_wrap" name="TMINhum_cylinder" pos="0.003 -0.0255 0.0013" quat="-0.0348606 -0.0161876 -0.671884 0.739658" size="0.022 0.0565" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="TMAJ_LAThum_cylinder" pos="0.0007 -0.0443 -0.0055" quat="0.560987 0.513042 -0.468432 0.45017" size="0.007 0.02" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="PEC12hum_cylinder" pos="0.002 -0.0508 -0.0017" quat="0.623759 0.640765 0.289032 -0.341767" size="0.009 0.035" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="PEC23hh_sphere" pos="-0.0086 0.0021 -0.0004" size="0.02" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="PEC1hh_ellipsoid" pos="-0.0037 0.0005 -0.0025" quat="0.916754 -0.32328 -0.0902682 0.216573" size="0.02"/>
+                                <geom class="myoarm_wrap" name="PEC3hum_cylinder" pos="0.0009 -0.0551 -0.0004" quat="0.495166 0.406012 -0.520135 0.565176" size="0.008 0.05" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="LAT_TMAJhh_cylinder" pos="-0.0224 0.0102 0.0094" quat="0.931143 -0.140037 -0.0596766 -0.331362" size="0.007 0.0225" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="LAT_TMAJ2hh_sphere" pos="-0.0016 0.0092 0.0052" quat="0.988522 -0.0615953 0.137948 0.0010005" size="0.03" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="Elbow_BIC_BRD_ellipsoid" pos="0.0019 -0.289 -0.014" quat="0.995526 -0.0630434 0.0695304 0.0108779" size="0.015"/>
+                                <geom class="myoarm_wrap" name="TRIlonghh_ellipsoid" pos="-0.0078 -0.0041 -0.0014" quat="0.414166 0.226558 -0.879857 -0.0546691" size="0.02"/>
+                                <geom class="myoarm_wrap" name="TRI_cylinder" pos="0.0028 -0.2919 -0.4219" quat="0.994531 -0.0700249 0.0022946 0.0774514" size="0.016 0.05" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="ANC_ellipsoid" pos="0.0134 -0.2861 -0.0008" quat="0.86157 -0.0459397 -0.0868616 0.498038" size="0.02"/>
+                                <geom class="myoarm_wrap" name="BIClong_ellipsoid" pos="0.0033 0.005 0.0003" quat="0.227685 -0.774064 0.117793 0.578886" size="0.02"/>
+                                <geom class="myoarm_wrap" name="TMAJ_LAT_PEC_CORBhh_sphere" pos="0.0007 0.035 0.006" size="0.03" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="DELT_TMAJ_LAT_PEC_CORBhh_sphere" pos="0.0007 0 0.006" size="0.03"/>
+                                <geom class="myoarm_wrap" name="CORBhum_cylinder" pos="0.0027 -0.1202 -0.0059" quat="0.642357 -0.637406 0.335002 0.262422" size="0.008 0.05" type="cylinder" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="Elbow_PT_ECRL_ellipsoid" pos="0.003 -0.2872 -0.0069" quat="0.947273 -0.0932693 -0.0283097 0.305242" size="0.018"/>
+                                <geom class="myoarm_wrap" name="LIGhh_s_ellipsoid_s_glenohum" pos="-0.001 0.003 0.003" quat="0.923956 -0.382499 0 0" size="0.02"/>
+                                <geom class="myoarm_wrap" name="LIGhh_mi_ellipsoid_m_glenohum" pos="-0.001 0.004 0.001" quat="0.923956 -0.382499 0 0" size="0.019"/>
+                                <geom class="myoarm_wrap" name="LIGhh_mi_ellipsoid_i_glenohum" pos="-0.001 0.004 0.001" quat="0.923956 -0.382499 0 0" size="0.019"/>
+                                <geom class="myoarm_wrap" name="LIGhh_s_ellipsoid_coracohum" pos="-0.001 0.003 0.003" quat="0.923956 -0.382499 0 0" size="0.02"/>
+                                <geom class="myoarm_wrap" name="DELT1hh_ellipsoid_DELT1" pos="-0.0179974 -0.0075035 -0.0580664" quat="0.83666 0.160028 0.454758 0.259973" size="0.029726" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="delt3hum_ellipsoid_DELT3" pos="0.0044 -0.0624 0.00443794" quat="0.156827 0.126209 0.749421 -0.630749" size="0.0125"/>
+                                <geom class="myoarm_wrap" name="SUPSP_ellipsoid_SUPSP" pos="0.00110546 0.00820496 0.00197985" quat="0.793859 0.0125049 0.0149602 -0.607789" size="0.0202151"/>
+                                <geom class="myoarm_wrap" name="SUBSCAP_ellipsoid_SUBSC" pos="0.0028089 -0.00313613 -0.00633073" quat="0.881836 -0.408886 0.210176 0.104899" size="0.0171729"/>
+                                <geom class="myoarm_wrap" name="INFSP_and_TMIN_hum_head_ellipsoid_TMIN" pos="-0.000927281 -0.000469167 0.00327226" quat="0.989183 -0.142571 -0.00937337 -0.0332047" size="0.025" rgba="1 0 0 0"/>
+                                <geom class="myoarm_wrap" name="PEC1hh_ellipsoid_PECM1" pos="0.0013 -0.0038025 -0.00251178" quat="0.916754 -0.32328 -0.0902682 0.216573" size="0.0221545"/>
+                                <geom class="myoarm_wrap" name="TRIlonghh_ellipsoid_TRIlong" pos="-0.00 -0.00 -0.00" quat="0.414166 0.226558 -0.879857 -0.0546691" size="0.02"/>
+                                <geom class="myoarm_wrap" name="ANC_ellipsoid_ANC" pos="0.0121714 -0.288051 -0.00144365" quat="0.86157 -0.0459397 -0.0868616 0.498038" size="0.0180029"/>
+                                <geom class="myoarm_wrap" name="Elbow_BIC_BRD_ellipsoid_BIClong" pos="0.00296577 -0.290569 -0.0201662" quat="0.995526 -0.0630434 0.0695304 0.0108779" size="0.0150371"/>
+                                <geom class="myoarm_wrap" name="BIClong_ellipsoid_BIClong" pos="0.0033 0.0015 0.0015" quat="0.227685 -0.774064 0.117793 0.578886" size="0.02"/>
+                                <geom class="myoarm_wrap" name="Elbow_BIC_BRD_ellipsoid_BICshort" pos="0.00286868 -0.290754 0.030545" quat="0.995526 -0.0630434 0.0695304 0.0108779" size="0.0162859"/>
 
-                                <geom class="wrap" name="ElbowBICBRD_ellipsoid_wrap" pos="0.0019 -0.289 0.054" quat="0.995524 -0.0630586 0.0695464 0.0108747" size="0.015 0.1" type="cylinder"/>
+                                <geom class="myoarm_wrap" name="ElbowBICBRD_ellipsoid_wrap" pos="0.0019 -0.289 0.054" quat="0.995524 -0.0630586 0.0695464 0.0108747" size="0.015 0.1" type="cylinder"/>
 
                                 <site name="DELT1hh_sidesite_r" pos="0.01226 -0.01367 -0.009599"/>
                                 <site name="delt3hum_sidesite_r" pos="-0.008209 -0.05929 -0.003236"/>
@@ -254,16 +254,16 @@
 
                                 <site name="TRI_site_BRA_side_r" pos="0.0188814 -0.25991 0.0179386"/>
 
-                                <site class="marker" name="Bicep_marker_r" pos="0.01591 -0.181 -0.00553"/>
-                                <site class="marker" name="Elbow_Lateral_marker_r" pos="0.00509 -0.2806 0.02884"/>
-                                <site class="marker" name="Elbow_Medial_marker_r" pos="-0.00407 -0.2844 -0.05408"/>
+                                <site class="myoarm_marker" name="Bicep_marker_r" pos="0.01591 -0.181 -0.00553"/>
+                                <site class="myoarm_marker" name="Elbow_Lateral_marker_r" pos="0.00509 -0.2806 0.02884"/>
+                                <site class="myoarm_marker" name="Elbow_Medial_marker_r" pos="-0.00407 -0.2844 -0.05408"/>
                                 <body name="ulna_r" pos="0.0061 -0.2904 -0.0123" childclass="elbow">
                                     <inertial diaginertia="0.00543663 0.00523521 0.001" mass="1.1053" pos="0.00971783 -0.0959509 0.024286" quat="0.792048 0.609078 0.0156735 0.0379256"/>
                                     <joint axis="0.0494004 0.0366003 0.998108" name="elbow_flexion_r" pos="0 0 0" range="0 2.269"/>
                                     <geom mesh="ulna_r" name="ulna_r" type="mesh"/>
-                                    <geom class="wrap" name="PQ2_cylinder" pos="-0.0012 -0.2092 0.0428" quat="0.540392 0.481982 -0.422482 0.545141" size="0.007 0.05" type="cylinder"/>
+                                    <geom class="myoarm_wrap" name="PQ2_cylinder" pos="-0.0012 -0.2092 0.0428" quat="0.540392 0.481982 -0.422482 0.545141" size="0.007 0.05" type="cylinder"/>
 
-                                    <geom class="wrap" name="PQ2_wrap" pos="-0.0012 -0.2092 0.0428" quat="0.540178 0.481989 -0.422693 0.545183" size="0.007 0.005" type="cylinder"/>
+                                    <geom class="myoarm_wrap" name="PQ2_wrap" pos="-0.0012 -0.2092 0.0428" quat="0.540178 0.481989 -0.422693 0.545183" size="0.007 0.005" type="cylinder"/>
                                     <geom name="ulna_coll_r" class="myoarm_coll" size="0.015" fromto="-.02 0 .005 .005 -0.2 0.04"/>
                                     <site name="ECU-P2_r" pos="-0.0139 -0.032 0.0295"/>
                                     <site name="ECU-P3_r" pos="-0.017 -0.0543 0.0287"/>
@@ -289,7 +289,7 @@
                                     <site name="ANC_ANC-P2_r" pos="-0.02532 -0.00124 0.006"/>
                                     <site name="SUP_SUP-P3_r" pos="-0.0136 -0.03384 0.02013"/>
                                     <site name="BRA_BRA-P4_r" pos="-0.0032 -0.0239 0.0009"/>
-                                    <site class="marker" name="Ulna_marker_r" pos="-0.01672 -0.2416 0.04782"/>
+                                    <site class="myoarm_marker" name="Ulna_marker_r" pos="-0.01672 -0.2416 0.04782"/>
                                     <body name="radius_r" pos="0.0004 -0.0115 0.02">
                                         <inertial diaginertia="0.001 0.001 0.001" mass="0.23359" pos="0.0336341 -0.181559 0.0156" quat="0.770264 0.63559 0.0119833 0.0507376"/>
 
@@ -305,9 +305,9 @@
                                         <geom name="radius_coll_3_r" class="myohand_coll" size="0.02" fromto="-.01 0 -.010 0.015 -0.24 0.025"/>
                                         <geom mesh="radius_r" name="radius_r" type="mesh"/>
 
-                                        <geom name="SUP_wrap" pos="0.0045 -0.0437 0.0059" quat="0.348354 0.118086 0.653837 -0.661213" class="wrap" size="0.008 0.02" type="cylinder"/>
-                                        <geom name="PQ1_wrap" pos="0.0281 -0.1986 0.0288" quat="0.15975 -0.156797 -0.702725 -0.675331" class="wrap" size="0.01 0.005" type="cylinder"/>
-                                        <geom name="ECU_torus_wrap" pos="-0.0163 -0.2417 0.0349" quat="0.868975 -0.476593 -0.0126204 0.132601" class="wrap" size="0.003"/>
+                                        <geom name="SUP_wrap" pos="0.0045 -0.0437 0.0059" quat="0.348354 0.118086 0.653837 -0.661213" class="myoarm_wrap" size="0.008 0.02" type="cylinder"/>
+                                        <geom name="PQ1_wrap" pos="0.0281 -0.1986 0.0288" quat="0.15975 -0.156797 -0.702725 -0.675331" class="myoarm_wrap" size="0.01 0.005" type="cylinder"/>
+                                        <geom name="ECU_torus_wrap" pos="-0.0163 -0.2417 0.0349" quat="0.868975 -0.476593 -0.0126204 0.132601" class="myoarm_wrap" size="0.003"/>
 
                                         <site name="ECRL-P2_r" pos="0.032 -0.1346 0.0278"/>
                                         <site name="ECRL-P3_r" pos="0.0424 -0.2368 0.0362"/>
@@ -359,9 +359,9 @@
                                         <site name="APL-P5_r" pos="0.055 -0.2308 0.0237"/>
                                         <site name="ECU_torus_site_ECU_side_r" pos="-0.0163 -0.2417 0.0349"/>
 
-                                        <geom class="wrap" name="SUP_cylinder" pos="0.0045 -0.0437 0.0059" quat="0.348335 0.118148 0.653915 -0.661134" size="0.008 0.02" type="cylinder"/>
-                                        <geom class="wrap" name="ECU_torus" pos="-0.0163 -0.2417 0.0349" quat="0.868982 -0.476579 -0.0126339 0.132605" size="0.006"/>
-                                        <geom class="wrap" name="PQ1_cylinder" pos="0.0281 -0.1986 0.0288" quat="0.159804 -0.156915 -0.702833 -0.675179" size="0.01 0.05" type="cylinder"/>
+                                        <geom class="myoarm_wrap" name="SUP_cylinder" pos="0.0045 -0.0437 0.0059" quat="0.348335 0.118148 0.653915 -0.661134" size="0.008 0.02" type="cylinder"/>
+                                        <geom class="myoarm_wrap" name="ECU_torus" pos="-0.0163 -0.2417 0.0349" quat="0.868982 -0.476579 -0.0126339 0.132605" size="0.006"/>
+                                        <geom class="myoarm_wrap" name="PQ1_cylinder" pos="0.0281 -0.1986 0.0288" quat="0.159804 -0.156915 -0.702833 -0.675179" size="0.01 0.05" type="cylinder"/>
                                         <site name="SUP_sidesite_r" pos="0.01106 -0.04094 0.01141"/>
                                         <site name="ECU_sidesite_r" pos="-0.0163 -0.2417 0.0349"/>
                                         <site name="SUP_SUP-P1_r" pos="0.00996 -0.06096 0.00075"/>
@@ -373,29 +373,29 @@
                                         <site name="BICshort_BICshort-P7_r" pos="-0.002 -0.0375 -0.002"/>
                                         <site name="BRD_BRD-P2_r" pos="0.03577 -0.12742 0.02315"/>
                                         <site name="BRD_BRD-P3_r" pos="0.0419 -0.221 0.0224"/>
-                                        <site class="marker" name="Forearm_marker_r" pos="0.03828 -0.1133 0.0174"/>
-                                        <site class="marker" name="Radius_marker_r" pos="0.05749 -0.2272 0.02738"/>
+                                        <site class="myoarm_marker" name="Forearm_marker_r" pos="0.03828 -0.1133 0.0174"/>
+                                        <site class="myoarm_marker" name="Radius_marker_r" pos="0.05749 -0.2272 0.02738"/>
 
                                         <body name="lunate_r" pos="0.018 -0.242 0.025" childclass="wrist">
                                             <joint axis="0 0 1" name="deviation_r" pos="0 0 0" range="-0.174533 0.436332" damping="0.25"/>
                                             <joint axis="1 0 0" name="flexion_r" pos="0 0 0" range="-0.785398 0.785398" damping="0.25"/>
                                             <geom mesh="lunate_r" name="lunate_r" type="mesh"/>
-                                            <geom name="WristExtensor_wrap" pos="0.0007 0 0.003" quat="0.807649 -0.0333177 0.588355 0.0207694" class="wrap" size="0.008 0.02" type="cylinder"/>
-                                            <geom name="WristFlexor_wrap" pos="0 -0.01 -0.004" quat="0.807649 -0.0333177 0.588355 0.0207694" class="wrap" size="0.007 0.02" type="cylinder"/>
-                                            <geom name="ExtensorEllipse_ellipsoid_wrap" pos="-0.00145969 -0.0120017 -0.00892632" quat="0.977473 -0.106567 0.15459 0.0963907" class="wrap" size="0.0237409"/>
-                                            <!-- <geom name="PL_ellipsoid_wrap" pos="0.0170362 -0.0128706 0.0101738" quat="0.998158 -0.0141897 0.050277 0.0308429" class="wrap" size="0.0272385"/> -->
-                                            <geom name="FDS_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="0.0012 -0.0057 0.0123" euler="0.00837758 1.48 -0.0171042" class="wrap"/>
-                                            <geom name="FDP_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="-0.0022 -0.0069 0.0182" euler="-1.46747 1.37 0.121824" class="wrap"/>
-                                            <geom name="EDM_ellipsoid_wrap" type="cylinder" size="0.014 0.018" pos="-0.0167 -0.0022 0.0048" euler="2.9627 1.73 0.117984" class="wrap"/>
-                                            <geom name="FPL_ellipsoid_wrap" type="sphere" size="0.015" pos="0.02 -0.025 -0.0033" class="wrap"/>
-                                            <geom name="ECRL_torus_wrap" pos="0.0222 -0.0096 0.0208" quat="0.637339 0.675155 -0.168467 0.331034" class="wrap" size="0.008"/>
-                                            <geom name="ECRB_torus_wrap" pos="0.0126 -0.0095 0.0186" quat="0.78744 0.610837 -0.011177 -0.0818018" class="wrap" size="0.002"/>
-                                            <geom name="FCR_torus_wrap" pos="0.0032 -0.0045 -0.019" quat="0.71204 -0.696183 -0.0894345 0.0181554" class="wrap" size="0.0015"/>
+                                            <geom name="WristExtensor_wrap" pos="0.0007 0 0.003" quat="0.807649 -0.0333177 0.588355 0.0207694" class="myoarm_wrap" size="0.008 0.02" type="cylinder"/>
+                                            <geom name="WristFlexor_wrap" pos="0 -0.01 -0.004" quat="0.807649 -0.0333177 0.588355 0.0207694" class="myoarm_wrap" size="0.007 0.02" type="cylinder"/>
+                                            <geom name="ExtensorEllipse_ellipsoid_wrap" pos="-0.00145969 -0.0120017 -0.00892632" quat="0.977473 -0.106567 0.15459 0.0963907" class="myoarm_wrap" size="0.0237409"/>
+                                            <!-- <geom name="PL_ellipsoid_wrap" pos="0.0170362 -0.0128706 0.0101738" quat="0.998158 -0.0141897 0.050277 0.0308429" class="myoarm_wrap" size="0.0272385"/> -->
+                                            <geom name="FDS_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="0.0012 -0.0057 0.0123" euler="0.00837758 1.48 -0.0171042" class="myoarm_wrap"/>
+                                            <geom name="FDP_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="-0.0022 -0.0069 0.0182" euler="-1.46747 1.37 0.121824" class="myoarm_wrap"/>
+                                            <geom name="EDM_ellipsoid_wrap" type="cylinder" size="0.014 0.018" pos="-0.0167 -0.0022 0.0048" euler="2.9627 1.73 0.117984" class="myoarm_wrap"/>
+                                            <geom name="FPL_ellipsoid_wrap" type="sphere" size="0.015" pos="0.02 -0.025 -0.0033" class="myoarm_wrap"/>
+                                            <geom name="ECRL_torus_wrap" pos="0.0222 -0.0096 0.0208" quat="0.637339 0.675155 -0.168467 0.331034" class="myoarm_wrap" size="0.008"/>
+                                            <geom name="ECRB_torus_wrap" pos="0.0126 -0.0095 0.0186" quat="0.78744 0.610837 -0.011177 -0.0818018" class="myoarm_wrap" size="0.002"/>
+                                            <geom name="FCR_torus_wrap" pos="0.0032 -0.0045 -0.019" quat="0.71204 -0.696183 -0.0894345 0.0181554" class="myoarm_wrap" size="0.0015"/>
 
-                                            <geom name="EDCL_torus_wrap" pos="-0.0128 -0.0133 0.0148" quat="0.386237 0.907673 0.159784 0.037683" class="wrap" size="0.004"/>
-                                            <geom name="EDCR_torus_wrap" pos="-0.0098 -0.0137 0.0166" quat="0.516906 0.814718 -0.18962 0.1819" class="wrap" size="0.003"/>
-                                            <geom name="EDCM_torus_wrap" pos="-0.0007 -0.0117 0.0191" quat="0.516192 0.831214 -0.100219 0.180516" class="wrap" size="0.0035"/>
-                                            <geom name="EDCI_torus_wrap" pos="0.009 -0.0149 0.0215" quat="0.660055 0.749868 0.0267535 0.0361877" class="wrap" size="0.0035"/>
+                                            <geom name="EDCL_torus_wrap" pos="-0.0128 -0.0133 0.0148" quat="0.386237 0.907673 0.159784 0.037683" class="myoarm_wrap" size="0.004"/>
+                                            <geom name="EDCR_torus_wrap" pos="-0.0098 -0.0137 0.0166" quat="0.516906 0.814718 -0.18962 0.1819" class="myoarm_wrap" size="0.003"/>
+                                            <geom name="EDCM_torus_wrap" pos="-0.0007 -0.0117 0.0191" quat="0.516192 0.831214 -0.100219 0.180516" class="myoarm_wrap" size="0.0035"/>
+                                            <geom name="EDCI_torus_wrap" pos="0.009 -0.0149 0.0215" quat="0.660055 0.749868 0.0267535 0.0361877" class="myoarm_wrap" size="0.0035"/>
                                             <site name="ExtensorEllipse_ellipsoid_site_EIP_side_r" pos="-0.0195105 -0.00430577 0.0636576"/>
                                             <site name="PL_ellipsoid_site_PL_side_r" pos="-0.0286005 -0.023546 -0.0168168"/>
 
@@ -425,7 +425,7 @@
                                             </body>
                                             <body name="pisiform_r" pos="-0.013388 -0.009886 -0.010593">
                                                 <geom mesh="pisiform_r" name="pisiform_r" type="mesh"/>
-                                                <!--<geom name="FCU_wrap" pos="0 0 0.006" quat="0.600794 -0.4144 0.573042 -0.372748" class="wrap" size="0.005 0.01" type="cylinder"/> -->
+                                                <!--<geom name="FCU_wrap" pos="0 0 0.006" quat="0.600794 -0.4144 0.573042 -0.372748" class="myoarm_wrap" size="0.005 0.01" type="cylinder"/> -->
                                                 <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                 <site name="FCU-P4_r" pos="0.001 0.003 -0.01"/>
                                             </body>
@@ -452,7 +452,7 @@
                                                 <body name="trapezium_r" pos="0.015293 -0.004569 -0.010308">
                                                     <geom mesh="trapezium_r" name="trapezium_r" type="mesh"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
-                                                    <!-- <geom name="Trpzm_wrap" pos="0.002 -0.003 0" quat="0.708942 0.660448 0.181023 0.16864" class="wrap" size="0.011"/> -->
+                                                    <!-- <geom name="Trpzm_wrap" pos="0.002 -0.003 0" quat="0.708942 0.660448 0.181023 0.16864" class="myoarm_wrap" size="0.011"/> -->
                                                     <site name="EPL-P7_r" pos="0.0081 -0.0046 0.0099"/>
                                                     <site name="OP-P1_r" pos="-0.011 -0.005 -0.004"/>
                                                     <site name="Trpzm_site_FPL_side_r" pos="0.0125474 -0.0222585 0.00136571"/>
@@ -466,7 +466,7 @@
                                                         <joint axis="0.495557 0.731736 0.467959"  name="cmc_abduction" pos="0 0 0" range="-0.5 0.78"/>
                                                         <geom name="1mcskin_r" class="myohand_coll" size="0.0095" fromto="-.002 0.004 0.003 0.0165 -0.0292 -0.0127"/>
                                                         <geom mesh="1mc_r" name="1mc_r" type="mesh"/>
-                                                        <geom name="MPthumb_wrap" type="cylinder" size="0.0085 0.01" pos="0.0177 -0.0305 -0.0143" euler="0.32131512 0.11013028 -0.83479098" class="wrap"/>
+                                                        <geom name="MPthumb_wrap" type="cylinder" size="0.0085 0.01" pos="0.0177 -0.0305 -0.0143" euler="0.32131512 0.11013028 -0.83479098" class="myoarm_wrap"/>
                                                         <inertial pos="0.0078 -0.0147 -0.006" mass="0.016" fullinertia="1.2e-06 7.1e-07 1.3e-06 4.7e-07 2.5e-07 -4.1e-07"/>
                                                         <site name="EPL-P8_r" pos="0.0066 -0.0043 0.0079"/>
                                                         <site name="EPL-P9_r" pos="0.0216 -0.0242 -0.0053"/>
@@ -490,7 +490,7 @@
                                                             <joint axis="-0.084295 -0.203488 0.975442" name="mp_flexion_r" pos="0 0 0" range="-0.785398 0.698132"/>
                                                             <geom name="proximal_thumb_coll_r" class="myohand_coll" size="0.0085" fromto="0 0 0 0.014 -0.0259 -0.0101"/>
                                                             <geom mesh="thumbprox_r" name="thumbprox" type="mesh"/>
-                                                            <geom name="IPthumb_wrap" type="cylinder" size="0.00450000 0.005" pos="0.0121 -0.0232 -0.0096" euler="0.30473449 0.01291544 0.08796459" class="wrap"/>
+                                                            <geom name="IPthumb_wrap" type="cylinder" size="0.00450000 0.005" pos="0.0121 -0.0232 -0.0096" euler="0.30473449 0.01291544 0.08796459" class="myoarm_wrap"/>
                                                             <inertial pos="0.0096 -0.0163 -0.0063" mass="0.0079" fullinertia="2.6e-07 7.1e-07 2.9e-07 1e-07 4e-08 -6e-08"/>
                                                             <site name="EPL-P10_r" pos="0.0115 -0.0036 0.0016"/>
                                                             <site name="EPL-P11_r" pos="0.0192 -0.0265 -0.0104"/>
@@ -520,14 +520,14 @@
                                                 </body>
                                                 <body name="hamate_r" pos="-0.010969 -0.002495 -0.00075">
                                                     <geom mesh="hamate_r" name="hamate_r" type="mesh"/>
-                                                    <!-- Never used <geom name="APL_torus_wrap" pos="0.0082 0.0023 -0.0101" quat="0.686412 -0.716478 0.0748666 -0.0994649" class="wrap" size="0.004"/> -->
+                                                    <!-- Never used <geom name="APL_torus_wrap" pos="0.0082 0.0023 -0.0101" quat="0.686412 -0.716478 0.0748666 -0.0994649" class="myoarm_wrap" size="0.004"/> -->
                                                     <site name="APL_torus_site_APL_side_r" pos="0.0082 0.0023 -0.0101"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                 </body>
                                                 <body name="secondmc_r" pos="0.014685 -0.03762 0.005032">
                                                     <geom name="2mcskin_coll_r" class="myohand_coll" size="0.010 0.028" euler="1.42 0.15 -.1"/>
                                                     <geom mesh="2mc_r" name="2mc_r" type="mesh"/>
-                                                    <geom name="2ndmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="0.0058 -0.0314 0.0007" euler="0.84927721 -1.33552594 1.33814394" class="wrap"/>
+                                                    <geom name="2ndmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="0.0058 -0.0314 0.0007" euler="0.84927721 -1.33552594 1.33814394" class="myoarm_wrap"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                     <!-- <site name="ECRL-P4_r" pos="0.0025 0.0164 0.0008"/>
                                                     <site name="FCR-P3_r" pos="-0.0034 0.0192 -0.0092"/>
@@ -569,7 +569,7 @@
                                                         <joint axis="-0.054999 0.085899 0.994785" name="mcp2_abduction_r" pos="0 0 0" range="-0.261799 0.261799"/>
                                                         <geom name="proxph2_coll_r" class="myohand_coll" size="0.009 0.020" pos="0.004 -0.0210 0.00362" euler="1.45 0.15 -.35"/>
                                                         <geom mesh="2proxph_r" name="2proxph_r" type="mesh"/>
-                                                        <geom name="Secondpm_wrap" type="cylinder" size="0.0042 0.005" pos="0.0075 -0.0407 0.0061" euler="0.74193947 -1.47393055 0.70965087" class="wrap"/>
+                                                        <geom name="Secondpm_wrap" type="cylinder" size="0.0042 0.005" pos="0.0075 -0.0407 0.0061" euler="0.74193947 -1.47393055 0.70965087" class="myoarm_wrap"/>
                                                         <inertial pos="0 0 0" mass="0.01" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                         <!-- <site name="FDS2-P6_r" pos="0.001 -0.001 -0.009"/>
                                                         <site name="FDS2-P7_r" pos="0.0064 -0.0368 0.0023"/>
@@ -605,7 +605,7 @@
                                                             <geom name="midph2_coll_r" class="myohand_coll" size="0.008 0.012" pos="0.0013 -0.012 0.00" euler="1.5 0.14 -.35"/>
                                                             <joint axis="0.97517 0.0998334 -0.197677" name="pm2_flexion_r" pos="0 0 0" range="0 1.5708"/>
                                                             <geom mesh="2midph_r" name="2midph_r" type="mesh"/>
-                                                            <geom name="Secondmd_wrap" pos="0.0036 -0.0243 0.0003" quat="0.749819 -0.0209733 -0.656264 0.0815428" class="wrap" size="0.003 0.005" type="cylinder"/>
+                                                            <geom name="Secondmd_wrap" pos="0.0036 -0.0243 0.0003" quat="0.749819 -0.0209733 -0.656264 0.0815428" class="myoarm_wrap" size="0.003 0.005" type="cylinder"/>
                                                             <inertial pos="0 0 0" mass="0.003" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                             <!-- <site name="FDS2-P8_r" pos="0.0013 -0.019 -0.0034"/>
                                                             <site name="FDP2-P8_r" pos="0.0007 -0.0089 -0.0077"/>
@@ -652,7 +652,7 @@
                                                     <geom name="3mcskin_coll_r" class="myohand_coll" size="0.010 0.028" euler="1.42 0.01 0" pos="0 0 0"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                     <geom mesh="3mc_r" name="3mc_r" type="mesh"/>
-                                                    <geom name="3rdmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="0.0016 -0.0271 0.0001" euler="-2.5794221 -1.44967048 2.90614774" class="wrap"/>
+                                                    <geom name="3rdmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="0.0016 -0.0271 0.0001" euler="-2.5794221 -1.44967048 2.90614774" class="myoarm_wrap"/>
                                                     <site name="ECRB-P4_r" pos="0.0045 0.0279 0.0011"/>
                                                     <site name="PL-P4_r" pos="0.0018 0.0083 -0.0024"/>
                                                     <site name="FDS4-P4_r" pos="-0.0091 0.0054 -0.0108"/>
@@ -686,7 +686,7 @@
                                                         <joint axis="0.980067 0 0.198669" name="mcp3_flexion_r" pos="0 0 0" range="0 1.5708"/>
                                                         <joint axis="-0.198669 0 0.980067" name="mcp3_abduction_r" pos="0 0 0" range="-0.261799 0.261799"/>
                                                         <geom mesh="3proxph_r" name="3proxph_r" type="mesh"/>
-                                                        <geom name="Thirdpm_wrap" pos="0.0017 -0.0439 0.005" quat="0.700673 0.00645453 -0.712452 0.0377825" class="wrap" size="0.004 0.005" type="cylinder"/>
+                                                        <geom name="Thirdpm_wrap" pos="0.0017 -0.0439 0.005" quat="0.700673 0.00645453 -0.712452 0.0377825" class="myoarm_wrap" size="0.004 0.005" type="cylinder"/>
                                                         <inertial pos="0 0 0" mass="0.01" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                         <!-- <site name="FDS3-P6_r" pos="0.0009 -0.017 -0.0128"/>
                                                         <site name="FDS3-P7_r" pos="0.001 -0.038 -0.002"/>
@@ -718,7 +718,7 @@
                                                             <geom name="midph3_coll_r" class="myohand_coll" size="0.008 0.014" pos="0.0012 -0.014 0.00" euler="1.55 0.06 -.35"/>
                                                             <geom mesh="3midph_r" name="3midph_r" type="mesh"/>
                                                             <inertial pos="0 0 0" mass="0.002" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
-                                                            <geom name="Thirdmd_wrap" pos="0.0014 -0.0289 0.0012" quat="0.708186 -0.0221627 -0.701515 0.0765368" class="wrap" size="0.003 0.005" type="cylinder"/>
+                                                            <geom name="Thirdmd_wrap" pos="0.0014 -0.0289 0.0012" quat="0.708186 -0.0221627 -0.701515 0.0765368" class="myoarm_wrap" size="0.003 0.005" type="cylinder"/>
                                                             <!-- <site name="FDS3-P8_r" pos="-0.001 -0.013 -0.006"/>
                                                             <site name="FDP3-P8_r" pos="-0.0001 -0.0103 -0.0072"/>
                                                             <site name="FDP3-P9_r" pos="0.0021 -0.0227 -0.0034"/>
@@ -753,8 +753,8 @@
                                                 <body name="fourthmc_r" pos="-0.012046 -0.040519 0.003513">
                                                     <geom name="4mcski_r" class="myohand_coll" size="0.0095 0.026" euler="1.55 -.08 0" pos=".001 0.002 -.00"/>
                                                     <geom mesh="4mc_r" name="4mc_r" type="mesh"/>
-                                                    <!-- <geom name="4thmcp_ellipsoid_wrap" pos="-0.00413111 -0.0311007 0.00480312" quat="0.562021 -0.225806 -0.785857 0.124787" class="wrap" size="0.00604155"/> -->
-                                                    <geom name="4thmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="-0.0003 -0.0254 -0.0003" euler="-2.97212118 -1.22173048 -2.46318317" class="wrap"/>
+                                                    <!-- <geom name="4thmcp_ellipsoid_wrap" pos="-0.00413111 -0.0311007 0.00480312" quat="0.562021 -0.225806 -0.785857 0.124787" class="myoarm_wrap" size="0.00604155"/> -->
+                                                    <geom name="4thmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="-0.0003 -0.0254 -0.0003" euler="-2.97212118 -1.22173048 -2.46318317" class="myoarm_wrap"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                     <!-- <site name="FDS5-P4_r" pos="-0.0029 0.0085 -0.0121"/>
                                                     <site name="FDS4-P5_r" pos="-0.0005 -0.0104 -0.0089"/>
@@ -784,8 +784,8 @@
                                                         <geom name="proxph4_coll_r" class="myohand_coll" size="0.0085 0.018" pos="-.001 -0.0200 .0008" euler="1.57 -.08 0"/>
                                                         <geom mesh="4proxph_r" name="4proxph_r" type="mesh"/>
                                                         <inertial pos="0 0 0" mass="0.01" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
-                                                        <geom name="Fourthpm_wrap" pos="-0.0033 -0.0401 -0.0001" quat="0.35623 -0.660837 -0.527455 0.397727" class="wrap" size="0.004 0.005" type="cylinder"/>
-                                                        <!--geom name="Fourthpm_wrap" type="cylinder" size="0.004  1e-2" pos="-3.3e-3 -4e-2 -1e-4" euler="-3.28989 -1.12312 -1.27252" class="wrap"/>-->
+                                                        <geom name="Fourthpm_wrap" pos="-0.0033 -0.0401 -0.0001" quat="0.35623 -0.660837 -0.527455 0.397727" class="myoarm_wrap" size="0.004 0.005" type="cylinder"/>
+                                                        <!--geom name="Fourthpm_wrap" type="cylinder" size="0.004  1e-2" pos="-3.3e-3 -4e-2 -1e-4" euler="-3.28989 -1.12312 -1.27252" class="myoarm_wrap"/>-->
                                                         <!-- <site name="FDS4-P6_r" pos="   19e-3 -2e-2 -49e-4"/>
                                                         <site name="FDS4-P7_r" pos="   11e-3 -33e-3 -63e-4"/>
                                                         <site name="FDP4-P6_r" pos="0.0018 -0.0199 -0.004"/>
@@ -815,7 +815,7 @@
                                                             <joint axis="0.921061 0 0.389418" name="pm4_flexion" pos="0 0 0" range="0 1.5708"/>
                                                             <geom name="midph4_coll_r" class="myohand_coll" size="0.0075 0.01" pos="-.00 -0.012 -.001" euler="1.58 -.08 0"/>
                                                             <geom mesh="4midph_r" name="4midph_r" type="mesh"/>
-                                                            <geom name="Fourthmd_wrap" type="cylinder" size="0.00300000 0.005" pos="-0.0021 -0.0247 -0.0001" euler="-3.02971705 -1.10287355 -2.87211382" class="wrap"/>
+                                                            <geom name="Fourthmd_wrap" type="cylinder" size="0.00300000 0.005" pos="-0.0021 -0.0247 -0.0001" euler="-3.02971705 -1.10287355 -2.87211382" class="myoarm_wrap"/>
                                                             <inertial pos="0 0 0" mass="0.003" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                             <!-- <site name="FDS4-P8_r" pos="-0.0009 -0.0147 -0.0021"/>
                                                             <site name="FDP4-P8_r" pos="0.001 -0.009 -0.007"/>
@@ -851,8 +851,8 @@
                                                 <body name="fifthmc_r" pos="-0.021896 -0.034683 -0.004218">
                                                     <geom name="5mcskin_r" class="myohand_coll" size="0.0095 0.024" euler="1.6 -.13 0" pos=".001 0.002 -.001"/>
                                                     <geom mesh="5mc_r" name="5mc_r" type="mesh"/>
-                                                    <!-- <geom name="5thmcp_ellipsoid_wrap" pos="0.00188166 -0.0190329 -0.0064628" quat="0.442485 -0.205619 -0.870066 -0.070096" class="wrap" size="0.00833444"/> -->
-                                                    <geom name="5thmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="-0.0004 -0.0218 -0.0037" euler="-2.67175002 -0.83479098 -2.4659757" class="wrap"/>
+                                                    <!-- <geom name="5thmcp_ellipsoid_wrap" pos="0.00188166 -0.0190329 -0.0064628" quat="0.442485 -0.205619 -0.870066 -0.070096" class="myoarm_wrap" size="0.00833444"/> -->
+                                                    <geom name="5thmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="-0.0004 -0.0218 -0.0037" euler="-2.67175002 -0.83479098 -2.4659757" class="myoarm_wrap"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                     <site name="ECU-P6_r" pos="-0.0006 0.0207 0.0029"/>
                                                     <site name="FCU-P5_r" pos="0.0015 0.017 -0.0033"/>
@@ -880,7 +880,7 @@
                                                         <joint axis="-0.564642 0 0.825336" name="mcp5_abduction_r" pos="0 0 0" range="-0.261799 0.261799"/>
                                                         <geom name="5proxph_coll_r" class="myohand_coll" size="0.008 0.016" pos="-.003 -0.018 -.002" euler="1.68 -.1 0"/>
                                                         <geom mesh="5proxph_r" name="5proxph_r" type="mesh"/>
-                                                        <geom name="Fifthpm_wrap" pos="-0.0046 -0.0349 -0.0042" quat="0.4295 -0.0398509 -0.90052 -0.0548241" class="wrap" size="0.004 0.005" type="cylinder"/>
+                                                        <geom name="Fifthpm_wrap" pos="-0.0046 -0.0349 -0.0042" quat="0.4295 -0.0398509 -0.90052 -0.0548241" class="myoarm_wrap" size="0.004 0.005" type="cylinder"/>
                                                         <inertial pos="0 0 0" mass="0.005" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                         <!-- <site name="FDS5-P6_r" pos="0.0018 -0.0143 -0.0055"/>
                                                         <site name="FDS5-P7_r" pos="0.001 -0.021 -0.007"/>
@@ -914,7 +914,7 @@
                                                             <joint axis="0.825336 0 0.564642" name="pm5_flexion_r" pos="0 0 0" range="0 1.5708"/>
                                                             <geom name="5midph_coll_r" class="myohand_coll" size="0.007 0.009" pos="-.001 -0.011 -.0025" euler="1.68 -.12 0"/>
                                                             <geom mesh="5midph_r" name="5midph_r" type="mesh"/>
-                                                            <geom name="Fifthmd_wrap" pos="-0.0025 -0.0205 -0.0025" quat="0.35929 -0.0253303 -0.929016 -0.0848458" class="wrap" size="0.003 0.005" type="cylinder"/>
+                                                            <geom name="Fifthmd_wrap" pos="-0.0025 -0.0205 -0.0025" quat="0.35929 -0.0253303 -0.929016 -0.0848458" class="myoarm_wrap" size="0.003 0.005" type="cylinder"/>
                                                             <inertial pos="0 0 0" mass="0.002" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                             <site name="FDS5-P8_r" pos="0.0011 -0.0182 -0.0046"/>
                                                             <site name="FDP5-P8_r" pos="-0.001 -0.009 -0.004"/>

--- a/myo_sim/models/torso/assets/myotorso_assets.xml
+++ b/myo_sim/models/torso/assets/myotorso_assets.xml
@@ -36,10 +36,10 @@
 			<default class="sidesite">
 				<site group="3" size="0.0005" />
 			</default>
-			<default class="wrap">
+			<default class="myotorso_wrap">
 				<geom group="3" rgba="0.19 0.83 0.78 0.2" contype="0" conaffinity="0" />
 			</default>
-			<default class="marker">
+			<default class="myotorso_marker">
 				<site rgba="1 0.1 0.5 0.5" size="0.001" group="4" />
 			</default>
 			<default class="motor">

--- a/myo_sim/models/torso/assets/myotorso_chain.xml
+++ b/myo_sim/models/torso/assets/myotorso_chain.xml
@@ -505,12 +505,12 @@
                   <geom name="torso_geom_13" pos="0.028 0.365 0" type="mesh"  mesh="torso_geom_13_ribcage_s"/>
                   <body name="Arm_attachment" pos="0.02 0.37 0" euler="-1.57079632679 0 1.57079632679">
                     <body name="chest_r" pos="0 0 0" euler="1.57079632679 -1.57079632679 0">
-                      <geom class="wrap" name="Thorax_ellipsoid" pos="-0.0386 -0.1273 0.0709" quat="0.98192 0.00567093 -0.166487 0.0899079" size="0.08"/>
-                      <geom class="wrap" name="thorax_ellipsoid_l" pos="-0.0386 -0.1273 -0.0709" quat="0.98192 -0.00567093 0.166487 0.0899079" size="0.08"/>
-                      <geom class="wrap" name="Thorax_ellipsoid_PECM2" pos="-0.0386 -0.1273 0.0709" quat="0.98192 0.00567093 -0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
-                      <geom class="wrap" name="thorax_ellipsoid_PECM2_l" pos="-0.0386 -0.1273 -0.0709" quat="0.98192 -0.00567093 0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
-                      <geom class="wrap" name="Thorax_ellipsoid_PECM3" pos="-0.0386 -0.1273 0.0709" quat="0.98192 0.00567093 -0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
-                      <geom class="wrap" name="thorax_ellipsoid_PECM3_l" pos="-0.0386 -0.1273 -0.0709" quat="0.98192 -0.00567093 0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
+                      <geom class="myotorso_wrap" name="Thorax_ellipsoid" pos="-0.0386 -0.1273 0.0709" quat="0.98192 0.00567093 -0.166487 0.0899079" size="0.08"/>
+                      <geom class="myotorso_wrap" name="thorax_ellipsoid_l" pos="-0.0386 -0.1273 -0.0709" quat="0.98192 -0.00567093 0.166487 0.0899079" size="0.08"/>
+                      <geom class="myotorso_wrap" name="Thorax_ellipsoid_PECM2" pos="-0.0386 -0.1273 0.0709" quat="0.98192 0.00567093 -0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
+                      <geom class="myotorso_wrap" name="thorax_ellipsoid_PECM2_l" pos="-0.0386 -0.1273 -0.0709" quat="0.98192 -0.00567093 0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
+                      <geom class="myotorso_wrap" name="Thorax_ellipsoid_PECM3" pos="-0.0386 -0.1273 0.0709" quat="0.98192 0.00567093 -0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
+                      <geom class="myotorso_wrap" name="thorax_ellipsoid_PECM3_l" pos="-0.0386 -0.1273 -0.0709" quat="0.98192 -0.00567093 0.166487 0.0899079" size="0.08" rgba="1 0 0 0"/>
                       <site name="PECM2_PECM2-P3_r" pos="0.03091 -0.03922 0.09705"/>
                       <site name="PECM2_PECM2-P3_l" pos="0.03091 -0.03922 -0.09705"/>
                       <site name="PECM2_PECM2-P4_r" pos="0.02769 -0.04498 0.02271"/>
@@ -541,8 +541,8 @@
                       <site name="LAT3_LAT3-P5_l" pos="-0.11157 -0.19387 -0.05532"/>
                       <site name="LAT3_LAT3-P6_r" pos="-0.07117 -0.24858 0.00907"/>
                       <site name="LAT3_LAT3-P6_l" pos="-0.07117 -0.24858 -0.00907"/>
-                      <site class="marker" name="C7_marker_r" pos="-0.05613 0.05528 -0.00151"/>
-                      <site class="marker" name="C7_marker_l" pos="-0.05613 0.05528 0.00151"/>
+                      <site class="myotorso_marker" name="C7_marker_r" pos="-0.05613 0.05528 -0.00151"/>
+                      <site class="myotorso_marker" name="C7_marker_l" pos="-0.05613 0.05528 0.00151"/>
                       <site name="TMAJ_LAT_PEC_CORBhh_sphere_PECM2_2_sidesite_r" pos="0.0510248 -0.016092 -0.0573453" rgba="1 0 0 0"/>
                       <site name="TMAJ_LAT_PEC_CORBhh_sphere_PECM2_2_sidesite_l" pos="0.0510248 -0.016092 0.0573453" rgba="1 0 0 0"/>
                       <body name="cervical_spine" pos="-0.03634 0.025 0">

--- a/tests/test_contact_paths.py
+++ b/tests/test_contact_paths.py
@@ -36,10 +36,13 @@ def test_model_xml_paths_do_not_reference_old_repo_layout():
 
 
 def test_no_static_xml_combines_conflicting_asset_files():
-    """MuJoCo 3.8 rejects models that include two *_assets.xml files sharing class names.
+    """Enforce policy: no static XML may combine myotorso_assets.xml and myoarm_r_assets.xml.
 
-    myotorso_assets.xml and myoarm_r_assets.xml both declare class="main", "wrap", and
-    "marker". Any static top-level XML that includes both will fail to load.
+    Before the rename in this PR, both files declared class="wrap" and class="marker",
+    causing MuJoCo 3.8 to raise "repeated default class name". Those names are now
+    scoped (myotorso_wrap, myoarm_wrap, etc.) so the pair can in principle be composed,
+    but multi-part assemblies must still go through build_model() in compose.py to keep
+    contact pairs and bilateral symmetry centralised.
     """
     conflicting_pairs = [
         ("myotorso_assets.xml", "myoarm_r_assets.xml"),
@@ -53,7 +56,7 @@ def test_no_static_xml_combines_conflicting_asset_files():
             includes_a = a in source
             includes_b = b in source
             assert not (includes_a and includes_b), (
-                f"{model_xml} includes both {a} and {b}, which share duplicate "
-                f"MuJoCo default class names (wrap, marker, main) and will fail "
-                f"to load on MuJoCo >= 3.8. Use build_model() instead."
+                f"{model_xml} includes both {a} and {b}. "
+                f"Multi-part assemblies must use build_model() in compose.py "
+                f"to keep contact pairs and bilateral symmetry centralised."
             )

--- a/tests/test_contact_paths.py
+++ b/tests/test_contact_paths.py
@@ -33,3 +33,27 @@ def test_model_xml_paths_do_not_reference_old_repo_layout():
 
         for prefix in stale_prefixes:
             assert prefix not in source, f"{model_xml} contains stale path prefix {prefix!r}"
+
+
+def test_no_static_xml_combines_conflicting_asset_files():
+    """MuJoCo 3.8 rejects models that include two *_assets.xml files sharing class names.
+
+    myotorso_assets.xml and myoarm_r_assets.xml both declare class="main", "wrap", and
+    "marker". Any static top-level XML that includes both will fail to load.
+    """
+    conflicting_pairs = [
+        ("myotorso_assets.xml", "myoarm_r_assets.xml"),
+    ]
+
+    for model_xml in MODELS_DIR.rglob("*.xml"):
+        if "assets" in model_xml.parts:
+            continue
+        source = model_xml.read_text()
+        for a, b in conflicting_pairs:
+            includes_a = a in source
+            includes_b = b in source
+            assert not (includes_a and includes_b), (
+                f"{model_xml} includes both {a} and {b}, which share duplicate "
+                f"MuJoCo default class names (wrap, marker, main) and will fail "
+                f"to load on MuJoCo >= 3.8. Use build_model() instead."
+            )


### PR DESCRIPTION
Closes #94.

MuJoCo 3.8 rejects models where two included asset files both declare `<default class="main">`. When torso and arm assets are combined (e.g. in myoarm_tabletennis.xml), the duplicate "main" name causes a hard parse error that was silently accepted in 3.7.

This adds a rule to CLAUDE.md banning `class="main"` in any `*_assets.xml` and specifying the required body-part-scoped naming (myoarm_main, myotorso_main, etc.), with a table of affected files and a reminder to update childclass references in body/chain files. The actual rename of the affected XML files is tracked separately in issue #94.