### PR TITLE
Trim runtime deps, fix CI coverage, and test max Python/MuJoCo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dev dependencies
         run: uv sync --dev
@@ -29,13 +29,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test the supported floor and the newest Python so compatibility with
+        # the maximum version is always verified.
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
-          python-version: "3.11"
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install system dependencies for MuJoCo
         run: |
@@ -45,5 +51,13 @@ jobs:
       - name: Install package
         run: uv sync --dev
 
+      - name: Upgrade to the latest MuJoCo release
+        # The lockfile pins MuJoCo for reproducible local dev; CI always tests
+        # against the newest release so upstream breakage is caught early.
+        run: uv pip install --upgrade mujoco
+
+      - name: Report versions under test
+        run: uv run python -c "import sys, mujoco; print('python', sys.version); print('mujoco', mujoco.__version__)"
+
       - name: Run tests
-        run: uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py --ignore=tests/test_bimanual_muscle_symmetry.py -q
+        run: uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py -q

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -122,11 +122,11 @@ def get_path(rel: str) -> Path:
     """Return the absolute Path to a model file by relative path within MODELS_DIR.
 
     This is a convenience wrapper for scripts and tutorials that prefer to
-    reference models by relative path (e.g. ``"arm/myoarm.xml"``) rather than
-    registry name.
+    reference models by relative path (e.g. ``"scene/myosuite_scene.xml"``)
+    rather than registry name.
 
     Args:
-        rel: Relative path inside MODELS_DIR, e.g. ``"arm/myoarm.xml"``.
+        rel: Relative path inside MODELS_DIR, e.g. ``"scene/myosuite_scene.xml"``.
 
     Returns:
         Absolute Path to the file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ requires-python = ">=3.10"
 dependencies = [
     "mujoco>=3.0",
     "numpy>=1.24",
-    "matplotlib>=3.7",
-    "scipy>=1.10",
 ]
 
 [dependency-groups]
@@ -16,6 +14,9 @@ dev = [
     "pytest-xdist>=3.0",
     "ruff>=0.4",
     "pre-commit>=3.0",
+    # Used only by the muscle-analysis / symmetry scripts under tests/.
+    "matplotlib>=3.7",
+    "scipy>=1.10",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -714,37 +714,37 @@ name = "myo-sim"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "matplotlib", specifier = ">=3.7" },
     { name = "mujoco", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.24" },
-    { name = "scipy", specifier = ">=1.10" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "matplotlib", specifier = ">=3.7" },
     { name = "pre-commit", specifier = ">=3.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "ruff", specifier = ">=0.4" },
+    { name = "scipy", specifier = ">=1.10" },
 ]
 
 [[package]]


### PR DESCRIPTION
Small packaging and CI cleanups found while reviewing the repository ahead of the 0.2.0 publish. No model or API changes.

`matplotlib` and `scipy` were declared under `[project].dependencies` but are imported only by the muscle-analysis and symmetry scripts under `tests/`, so every `pip install myo-sim` pulled them in needlessly. They move to the `dev` dependency group. `numpy` stays a runtime dependency because `build/hand.py` uses it.

CI ignored `tests/test_bimanual_muscle_symmetry.py`, which passes reliably (about 26s) and covers bimanual arm mirror symmetry. The exclusion, added in the original `#111` refactor, meant that check ran locally but never in CI. It is re-enabled. The `tests/test_equivalence.py` ignore stays, because that test needs the external `musclemimic_models` package and skips without it.

The test job now runs on a matrix of the supported floor (`3.10`) and the newest Python (`3.13`), and upgrades to the latest MuJoCo release before running, so compatibility with the maximum Python and MuJoCo versions is always verified rather than only the single pinned combination. A step prints the Python and MuJoCo versions under test. The lockfile still pins MuJoCo for reproducible local development; CI intentionally tests the leading edge to catch upstream breakage early.

Finally, the `get_path` docstring example referenced `arm/myoarm.xml`, a path removed during the model reorganization, so the example itself would raise. It now uses `scene/myosuite_scene.xml`.

Verified: full suite passes (105 passed, bimanual included), ruff check and format clean.
