### PR TITLE
Add muscle FL-bound / lengthrange verification (shows calibration gaps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,63 @@ jobs:
         run: uv run python -c "import sys, mujoco; print('python', sys.version); print('mujoco', mujoco.__version__)"
 
       - name: Run tests
-        run: uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py -q
+        run: >
+          uv run pytest tests/ -x -n auto -q
+          --ignore=tests/test_equivalence.py
+          --ignore=tests/test_muscle_length_params.py
+
+  # Muscle lengthrange / FL-bound audits are expensive and currently expected to
+  # fail on shipped models (shared lmin/lmax defaults, path vs lengthrange drift).
+  # Run them only when model XML or the audit tooling itself changes.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      muscle_models: ${{ steps.filter.outputs.muscle_models }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            muscle_models:
+              - 'myo_sim/models/**/*.xml'
+              - 'tests/test_muscle_length_params.py'
+              - 'tests/recalc_from_fl_bounds.py'
+              - 'tests/muscle_analysis_utils.py'
+
+  muscle-params:
+    runs-on: ubuntu-latest
+    needs: [lint, changes]
+    if: needs.changes.outputs.muscle_models == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.13"
+
+      - name: Install system dependencies for MuJoCo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libglib2.0-0 libosmesa6
+
+      - name: Install package
+        run: uv sync --dev
+
+      - name: Upgrade to the latest MuJoCo release
+        run: uv pip install --upgrade mujoco
+
+      - name: Verify lengthrange / operating range / FL bounds
+        run: uv run pytest tests/test_muscle_length_params.py -v --tb=short
+
+      - name: Report FL diversity + violations (CLI)
+        if: failure()
+        run: >
+          uv run python tests/recalc_from_fl_bounds.py --model myoarm_r --verify-only;
+          uv run python tests/recalc_from_fl_bounds.py --model myolegs --verify-only;
+          uv run python tests/recalc_from_fl_bounds.py --model myotorso --verify-only;
+          true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,63 +60,9 @@ jobs:
         run: uv run python -c "import sys, mujoco; print('python', sys.version); print('mujoco', mujoco.__version__)"
 
       - name: Run tests
+        # Skip manual / pre-release audits (equivalence, bimanual, muscle FL bounds).
         run: >
           uv run pytest tests/ -x -n auto -q
           --ignore=tests/test_equivalence.py
+          --ignore=tests/test_bimanual_muscle_symmetry.py
           --ignore=tests/test_muscle_length_params.py
-
-  # Muscle lengthrange / FL-bound audits are expensive and currently expected to
-  # fail on shipped models (shared lmin/lmax defaults, path vs lengthrange drift).
-  # Run them only when model XML or the audit tooling itself changes.
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      muscle_models: ${{ steps.filter.outputs.muscle_models }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            muscle_models:
-              - 'myo_sim/models/**/*.xml'
-              - 'tests/test_muscle_length_params.py'
-              - 'tests/recalc_from_fl_bounds.py'
-              - 'tests/muscle_analysis_utils.py'
-
-  muscle-params:
-    runs-on: ubuntu-latest
-    needs: [lint, changes]
-    if: needs.changes.outputs.muscle_models == 'true'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          python-version: "3.13"
-
-      - name: Install system dependencies for MuJoCo
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libglib2.0-0 libosmesa6
-
-      - name: Install package
-        run: uv sync --dev
-
-      - name: Upgrade to the latest MuJoCo release
-        run: uv pip install --upgrade mujoco
-
-      - name: Verify lengthrange / operating range / FL bounds
-        run: uv run pytest tests/test_muscle_length_params.py -v --tb=short
-
-      - name: Report FL diversity + violations (CLI)
-        if: failure()
-        run: >
-          uv run python tests/recalc_from_fl_bounds.py --model myoarm_r --verify-only;
-          uv run python tests/recalc_from_fl_bounds.py --model myolegs --verify-only;
-          uv run python tests/recalc_from_fl_bounds.py --model myotorso --verify-only;
-          true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: uv run python -c "import sys, mujoco; print('python', sys.version); print('mujoco', mujoco.__version__)"
 
       - name: Run tests
-        # Skip manual / pre-release audits (equivalence, bimanual, muscle FL bounds).
+        # Skip manual audits (equivalence, bimanual, muscle FL bounds).
         run: >
           uv run pytest tests/ -x -n auto -q
           --ignore=tests/test_equivalence.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,39 @@ on:
   workflow_dispatch:
 
 jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.13"
+
+      - name: Install system dependencies for MuJoCo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libglib2.0-0 libosmesa6
+
+      - name: Install package
+        run: uv sync --dev
+
+      - name: Upgrade to the latest MuJoCo release
+        run: uv pip install --upgrade mujoco
+
+      - name: Default test suite
+        run: >
+          uv run pytest tests/ -x -n auto -q
+          --ignore=tests/test_equivalence.py
+          --ignore=tests/test_bimanual_muscle_symmetry.py
+          --ignore=tests/test_muscle_length_params.py
+
+      - name: Pre-release muscle length / FL-bound audit
+        run: uv run pytest tests/test_muscle_length_params.py -v --tb=short
+
   build:
+    needs: pre-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,39 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pre-release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          python-version: "3.13"
-
-      - name: Install system dependencies for MuJoCo
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libglib2.0-0 libosmesa6
-
-      - name: Install package
-        run: uv sync --dev
-
-      - name: Upgrade to the latest MuJoCo release
-        run: uv pip install --upgrade mujoco
-
-      - name: Default test suite
-        run: >
-          uv run pytest tests/ -x -n auto -q
-          --ignore=tests/test_equivalence.py
-          --ignore=tests/test_bimanual_muscle_symmetry.py
-          --ignore=tests/test_muscle_length_params.py
-
-      - name: Pre-release muscle length / FL-bound audit
-        run: uv run pytest tests/test_muscle_length_params.py -v --tb=short
-
   build:
-    needs: pre-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,10 @@ Read `docs/wiki/index.md` before making any substantial change.
 uv sync
 
 # Run tests
-uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py
+uv run pytest tests/ -x -n auto \
+  --ignore=tests/test_equivalence.py \
+  --ignore=tests/test_bimanual_muscle_symmetry.py \
+  --ignore=tests/test_muscle_length_params.py
 
 # Compose a bilateral model
 uv run python -m myo_sim.build.compose --model myoarms

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ uv run pytest tests/ -x -n auto \
   --ignore=tests/test_bimanual_muscle_symmetry.py \
   --ignore=tests/test_muscle_length_params.py
 
-# Pre-release muscle length / FL-bound audit (also run by publish.yml)
+# Manual muscle length / FL-bound audit
 uv run pytest tests/test_muscle_length_params.py -v
 
 # Muscle symmetry analysis (standalone scripts, not pytest)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,10 @@ git clone https://github.com/MyoHub/myo_sim.git
 cd myo_sim
 uv sync --dev
 uv run pre-commit install
-uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py
+uv run pytest tests/ -x -n auto \
+  --ignore=tests/test_equivalence.py \
+  --ignore=tests/test_bimanual_muscle_symmetry.py \
+  --ignore=tests/test_muscle_length_params.py
 ```
 
 ## Branch and PR conventions
@@ -49,7 +52,11 @@ After conversion, any manual adjustments are documented in the relevant model's 
 # Fast gate — run before every PR
 uv run pytest tests/ -x -n auto \
   --ignore=tests/test_equivalence.py \
-  --ignore=tests/test_bimanual_muscle_symmetry.py
+  --ignore=tests/test_bimanual_muscle_symmetry.py \
+  --ignore=tests/test_muscle_length_params.py
+
+# Pre-release muscle length / FL-bound audit (also run by publish.yml)
+uv run pytest tests/test_muscle_length_params.py -v
 
 # Muscle symmetry analysis (standalone scripts, not pytest)
 cd tests && uv run python debug_muscle_leg.py

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ print(f"Full body — joints: {model.njnt}, muscles: {model.nu}")
 git clone https://github.com/MyoHub/myo_sim.git
 cd myo_sim
 uv sync --dev
-uv run pytest tests/ -x -n auto --ignore=tests/test_equivalence.py
+uv run pytest tests/ -x -n auto \
+  --ignore=tests/test_equivalence.py \
+  --ignore=tests/test_bimanual_muscle_symmetry.py \
+  --ignore=tests/test_muscle_length_params.py
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.

--- a/docs/wiki/testing-guide.md
+++ b/docs/wiki/testing-guide.md
@@ -18,11 +18,11 @@ Map of the test suite for agents working in `myo_sim`.
 | `test_torso_muscle_symmetry.py` | Torso muscle moment arms are symmetric between left and right | After `myotorso` XML changes |
 | `test_equivalence.py` | `myofullbody` joint and actuator counts match musclemimic reference spec | Manual only — needs musclemimic reference values |
 | `test_bimanual_muscle_symmetry.py` | Bimanual arm muscle moment arms are symmetric | Manual only |
-| `test_muscle_length_params.py` | `lengthrange` / operating range / FL `lmin`/`lmax` consistency | Pre-release only (`publish.yml`); use `tests/recalc_from_fl_bounds.py` to propose fixes |
+| `test_muscle_length_params.py` | `lengthrange` / operating range / FL `lmin`/`lmax` consistency | Manual only; use `tests/recalc_from_fl_bounds.py` to propose fixes |
 
 ## Fast Gate (Run Before Every PR)
 
-Run this before opening or updating a PR. It skips manual and pre-release audits:
+Run this before opening or updating a PR. It skips manual audits:
 
 ```bash
 uv run pytest tests/ -x -n auto \

--- a/docs/wiki/testing-guide.md
+++ b/docs/wiki/testing-guide.md
@@ -18,15 +18,17 @@ Map of the test suite for agents working in `myo_sim`.
 | `test_torso_muscle_symmetry.py` | Torso muscle moment arms are symmetric between left and right | After `myotorso` XML changes |
 | `test_equivalence.py` | `myofullbody` joint and actuator counts match musclemimic reference spec | Manual only — needs musclemimic reference values |
 | `test_bimanual_muscle_symmetry.py` | Bimanual arm muscle moment arms are symmetric | Manual only |
+| `test_muscle_length_params.py` | `lengthrange` / operating range / FL `lmin`/`lmax` consistency | Pre-release only (`publish.yml`); use `tests/recalc_from_fl_bounds.py` to propose fixes |
 
 ## Fast Gate (Run Before Every PR)
 
-Run this before opening or updating a PR. It skips the two manual-only tests:
+Run this before opening or updating a PR. It skips manual and pre-release audits:
 
 ```bash
 uv run pytest tests/ -x -n auto \
   --ignore=tests/test_equivalence.py \
-  --ignore=tests/test_bimanual_muscle_symmetry.py
+  --ignore=tests/test_bimanual_muscle_symmetry.py \
+  --ignore=tests/test_muscle_length_params.py
 ```
 
 The `-x` flag stops on first failure. The `-n auto` flag runs in parallel across available CPUs.

--- a/tests/recalc_from_fl_bounds.py
+++ b/tests/recalc_from_fl_bounds.py
@@ -1,0 +1,411 @@
+"""Recalculate lengthrange + operating range from FL-curve bounds (lmin/lmax).
+
+MuJoCo muscle ``gainprm`` / ``biasprm`` layout (relevant slots)::
+
+    [0] range[0]  operating-range lower  (r0)  — maps to lengthrange[0]
+    [1] range[1]  operating-range upper  (r1)  — maps to lengthrange[1]
+    [2] force     peak active force
+    [4] lmin      force-length curve lower
+    [5] lmax      force-length curve upper
+
+Normalized length at musculotendon length ``L``::
+
+    L_norm = r0 + (L - LR0) / L0
+    L0     = (LR1 - LR0) / (r1 - r0)
+
+Given new FL bounds ``(lmin, lmax)`` and a measured path ``[L_path_lo, L_path_hi]``,
+this utility places the operating band inside the FL curve and re-anchors
+``lengthrange`` so the path spans that band (mid-ROM at L_norm=1 by default).
+
+CLI::
+
+    uv run python tests/recalc_from_fl_bounds.py --model myoarm_r
+    uv run python tests/recalc_from_fl_bounds.py --model myoarm_r --muscle LAT1 --lmin 0.5 --lmax 1.6
+    uv run python tests/recalc_from_fl_bounds.py --model myotorso --verify-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+# tests/ is on pytest pythonpath; keep sibling imports working for CLI use.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from muscle_analysis_utils import (  # noqa: E402
+    apply_eq_constraints,
+    compute_moment_arm_curve,
+    parse_model_joint_equalities,
+)
+
+import myo_sim  # noqa: E402
+
+# Defaults: keep operating band inside FL with margin; mid-ROM at L_norm=1
+DEFAULT_BAND_FRAC = 0.15  # fraction of (lmax-lmin) inset from each end
+LR_MARGIN_M = 0.005
+PATH_SAMPLES = 80
+
+
+@dataclass
+class MuscleParams:
+    name: str
+    lengthrange: tuple[float, float]
+    r0: float
+    r1: float
+    lmin: float
+    lmax: float
+    fmax: float
+    l0_implied: float
+
+    @classmethod
+    def from_model(cls, model: mujoco.MjModel, name: str) -> MuscleParams:
+        aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+        if aid < 0:
+            raise ValueError(f"actuator {name!r} not found")
+        prm = model.actuator_gainprm[aid]
+        lr = model.actuator_lengthrange[aid]
+        r0, r1 = float(prm[0]), float(prm[1])
+        span = float(lr[1] - lr[0])
+        l0 = span / (r1 - r0) if abs(r1 - r0) > 1e-12 else float("nan")
+        return cls(
+            name=name,
+            lengthrange=(float(lr[0]), float(lr[1])),
+            r0=r0,
+            r1=r1,
+            lmin=float(prm[4]),
+            lmax=float(prm[5]),
+            fmax=float(prm[2]),
+            l0_implied=l0,
+        )
+
+
+@dataclass
+class PathSample:
+    joint: str
+    mtu_min: float
+    mtu_max: float
+
+
+@dataclass
+class RecalcProposal:
+    name: str
+    lmin: float
+    lmax: float
+    r0: float
+    r1: float
+    lengthrange_lo: float
+    lengthrange_hi: float
+    l0_implied: float
+    path: PathSample
+    current: MuscleParams
+
+
+@dataclass
+class Violation:
+    name: str
+    kind: str
+    detail: str
+
+
+def primary_joint(model, data, aid: int, eq_map) -> tuple[int, str]:
+    tid = model.actuator_trnid[aid, 0]
+    best = (-1, "", 0.0)
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            continue
+        qs, ma = compute_moment_arm_curve(model, data, tid, j, n=40, eq_map=eq_map)
+        if qs is None:
+            continue
+        score = float(np.mean(np.abs(ma)))
+        if score > best[2]:
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) or f"j{j}"
+            best = (j, name, score)
+    return best[0], best[1]
+
+
+def sample_path(model, data, eq_map, aid: int, jnt_id: int, n: int = PATH_SAMPLES) -> PathSample:
+    qadr = model.jnt_qposadr[jnt_id]
+    lo, hi = model.jnt_range[jnt_id]
+    jname = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, jnt_id) or f"j{jnt_id}"
+    lengths = []
+    for q in np.linspace(lo, hi, n):
+        data.qpos[:] = 0.0
+        data.qpos[qadr] = q
+        apply_eq_constraints(data, model, eq_map)
+        data.ctrl[:] = 0.0
+        mujoco.mj_forward(model, data)
+        lengths.append(float(data.actuator_length[aid]))
+    lengths = np.asarray(lengths)
+    return PathSample(joint=jname, mtu_min=float(lengths.min()), mtu_max=float(lengths.max()))
+
+
+def operating_band_from_fl(lmin: float, lmax: float, band_frac: float = DEFAULT_BAND_FRAC) -> tuple[float, float]:
+    """Place (r0, r1) inside [lmin, lmax], preferring to include 1.0 when possible."""
+    if lmax <= lmin:
+        raise ValueError(f"lmax ({lmax}) must be > lmin ({lmin})")
+    span = lmax - lmin
+    r0 = lmin + band_frac * span
+    r1 = lmax - band_frac * span
+    if r1 <= r0:
+        r0, r1 = lmin + 0.05 * span, lmax - 0.05 * span
+    # Prefer mid-ROM at L_norm=1: if 1 is inside (r0,r1) keep; else shift band to contain 1 if possible
+    if r0 < 1.0 < r1:
+        return r0, r1
+    if lmin < 1.0 < lmax:
+        half = 0.5 * (r1 - r0)
+        r0 = max(lmin, 1.0 - half)
+        r1 = min(lmax, 1.0 + half)
+        if r1 <= r0:
+            r0, r1 = lmin + band_frac * span, lmax - band_frac * span
+    return float(r0), float(r1)
+
+
+def lengthrange_from_path(
+    path: PathSample,
+    r0: float,
+    r1: float,
+    *,
+    margin_m: float = LR_MARGIN_M,
+) -> tuple[float, float, float, float, float]:
+    """Anchor mid-path at L_norm=1; span path (+margin) over (r0,r1).
+
+    Returns ``(LR0, LR1, L0, r0_out, r1_out)``.
+    """
+    mtu_lo = path.mtu_min - margin_m
+    mtu_hi = path.mtu_max + margin_m
+    mid = 0.5 * (path.mtu_min + path.mtu_max)
+    path_span = mtu_hi - mtu_lo
+    op_span = r1 - r0
+    if op_span <= 1e-12:
+        raise ValueError("operating range (r1-r0) too small")
+    l0 = path_span / op_span
+    lr0 = mid - (1.0 - r0) * l0
+    lr1 = lr0 + path_span
+    # Recompute r so mid stays at 1 after margin padding
+    r0_out = 1.0 - (mid - lr0) / l0
+    r1_out = r0_out + path_span / l0
+    return float(lr0), float(lr1), float(l0), float(r0_out), float(r1_out)
+
+
+def recalc_from_fl_bounds(
+    path: PathSample,
+    current: MuscleParams,
+    lmin: float | None = None,
+    lmax: float | None = None,
+    band_frac: float = DEFAULT_BAND_FRAC,
+) -> RecalcProposal:
+    """Propose lengthrange + r0/r1 for target FL bounds (default: keep current lmin/lmax)."""
+    lmin_u = current.lmin if lmin is None else float(lmin)
+    lmax_u = current.lmax if lmax is None else float(lmax)
+    r0_t, r1_t = operating_band_from_fl(lmin_u, lmax_u, band_frac)
+    lr0, lr1, l0, r0, r1 = lengthrange_from_path(path, r0_t, r1_t)
+    return RecalcProposal(
+        name=current.name,
+        lmin=lmin_u,
+        lmax=lmax_u,
+        r0=r0,
+        r1=r1,
+        lengthrange_lo=lr0,
+        lengthrange_hi=lr1,
+        l0_implied=l0,
+        path=path,
+        current=current,
+    )
+
+
+def apply_proposal_in_memory(model: mujoco.MjModel, proposal: RecalcProposal) -> None:
+    """Patch compiled model actuator params (gainprm + biasprm + lengthrange)."""
+    aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, proposal.name)
+    model.actuator_lengthrange[aid, 0] = proposal.lengthrange_lo
+    model.actuator_lengthrange[aid, 1] = proposal.lengthrange_hi
+    for arr in (model.actuator_gainprm[aid], model.actuator_biasprm[aid]):
+        arr[0] = proposal.r0
+        arr[1] = proposal.r1
+        arr[4] = proposal.lmin
+        arr[5] = proposal.lmax
+
+
+def verify_muscle(model, data, eq_map, name: str, *, path_n: int = PATH_SAMPLES) -> list[Violation]:
+    """Return parameter / path consistency violations for one muscle."""
+    cur = MuscleParams.from_model(model, name)
+    aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+    violations: list[Violation] = []
+
+    if cur.lmax <= cur.lmin:
+        violations.append(Violation(name, "fl_bounds", f"lmax={cur.lmax} <= lmin={cur.lmin}"))
+    if cur.r1 <= cur.r0:
+        violations.append(Violation(name, "operating_range", f"r1={cur.r1} <= r0={cur.r0}"))
+
+    # Operating band should lie within FL curve domain
+    eps = 1e-6
+    if cur.r0 < cur.lmin - eps or cur.r1 > cur.lmax + eps:
+        violations.append(
+            Violation(
+                name,
+                "operating_outside_fl",
+                f"r=[{cur.r0:.4f},{cur.r1:.4f}] outside lmin/lmax=[{cur.lmin:.4f},{cur.lmax:.4f}]",
+            )
+        )
+
+    jnt_id, jname = primary_joint(model, data, aid, eq_map)
+    if jnt_id < 0:
+        violations.append(Violation(name, "no_joint", "no hinge with moment arm"))
+        return violations
+
+    path = sample_path(model, data, eq_map, aid, jnt_id, n=path_n)
+    lr0, lr1 = cur.lengthrange
+    if path.mtu_min < lr0 - 1e-6 or path.mtu_max > lr1 + 1e-6:
+        violations.append(
+            Violation(
+                name,
+                "path_outside_lengthrange",
+                f"path=[{path.mtu_min:.4f},{path.mtu_max:.4f}] m on {jname} outside lengthrange=[{lr0:.4f},{lr1:.4f}]",
+            )
+        )
+
+    # Path-normalized lengths should fall in operating band (approx)
+    if abs(cur.l0_implied) > 1e-9 and np.isfinite(cur.l0_implied):
+        n_lo = cur.r0 + (path.mtu_min - lr0) / cur.l0_implied
+        n_hi = cur.r0 + (path.mtu_max - lr0) / cur.l0_implied
+        if n_hi < cur.lmin - 0.05 or n_lo > cur.lmax + 0.05:
+            violations.append(
+                Violation(
+                    name,
+                    "path_norm_outside_fl",
+                    f"path L_norm≈[{n_lo:.3f},{n_hi:.3f}] vs FL [{cur.lmin:.3f},{cur.lmax:.3f}]",
+                )
+            )
+
+    return violations
+
+
+def verify_model(model_name: str) -> list[Violation]:
+    model, data = myo_sim.load(model_name)
+    eq_map = parse_model_joint_equalities(model)
+    out: list[Violation] = []
+    for i in range(model.nu):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+        if not name:
+            continue
+        out.extend(verify_muscle(model, data, eq_map, name))
+    return out
+
+
+def fl_bound_diversity(model_name: str) -> dict:
+    """Summarize uniqueness of (lmin, lmax) — highlights shared defaults."""
+    model, _ = myo_sim.load(model_name)
+    counts: dict[tuple[float, float], int] = {}
+    for i in range(model.nu):
+        prm = model.actuator_gainprm[i]
+        key = (round(float(prm[4]), 6), round(float(prm[5]), 6))
+        counts[key] = counts.get(key, 0) + 1
+    return {
+        "model": model_name,
+        "n_actuators": model.nu,
+        "n_unique_fl_bounds": len(counts),
+        "counts": {f"{a},{b}": n for (a, b), n in sorted(counts.items(), key=lambda x: -x[1])},
+    }
+
+
+def propose_for_model(
+    model_name: str,
+    muscle: str | None = None,
+    lmin: float | None = None,
+    lmax: float | None = None,
+    band_frac: float = DEFAULT_BAND_FRAC,
+) -> list[RecalcProposal]:
+    model, data = myo_sim.load(model_name)
+    eq_map = parse_model_joint_equalities(model)
+    names = [muscle] if muscle else [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)]
+    proposals = []
+    for name in names:
+        if not name:
+            continue
+        cur = MuscleParams.from_model(model, name)
+        aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+        jnt_id, _ = primary_joint(model, data, aid, eq_map)
+        if jnt_id < 0:
+            continue
+        path = sample_path(model, data, eq_map, aid, jnt_id)
+        proposals.append(recalc_from_fl_bounds(path, cur, lmin=lmin, lmax=lmax, band_frac=band_frac))
+    return proposals
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", default="myoarm_r", help="Registered myo_sim model name")
+    ap.add_argument("--muscle", default=None, help="Single actuator; default=all")
+    ap.add_argument("--lmin", type=float, default=None, help="Target FL lmin (default: keep current)")
+    ap.add_argument("--lmax", type=float, default=None, help="Target FL lmax (default: keep current)")
+    ap.add_argument("--band-frac", type=float, default=DEFAULT_BAND_FRAC)
+    ap.add_argument("--verify-only", action="store_true", help="Only report violations")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    diversity = fl_bound_diversity(args.model)
+    print(f"=== FL bound diversity ({args.model}) ===")
+    print(f"  unique (lmin,lmax) pairs: {diversity['n_unique_fl_bounds']} / {diversity['n_actuators']}")
+    for k, n in list(diversity["counts"].items())[:5]:
+        print(f"    ({k}): {n}")
+
+    violations = verify_model(args.model)
+    by_kind: dict[str, int] = {}
+    for v in violations:
+        by_kind[v.kind] = by_kind.get(v.kind, 0) + 1
+    print(f"\n=== Verify ({len(violations)} violations) ===")
+    for kind, n in sorted(by_kind.items(), key=lambda x: -x[1]):
+        print(f"  {kind}: {n}")
+    for v in violations[:20]:
+        print(f"  [{v.kind}] {v.name}: {v.detail}")
+    if len(violations) > 20:
+        print(f"  ... +{len(violations) - 20} more")
+
+    payload: dict = {"diversity": diversity, "violations": [asdict(v) for v in violations]}
+
+    if not args.verify_only:
+        props = propose_for_model(args.model, args.muscle, args.lmin, args.lmax, args.band_frac)
+        print(f"\n=== Recalc proposals ({len(props)}) ===")
+        for p in props[:10]:
+            c = p.current
+            print(
+                f"  {p.name:16s} FL[{p.lmin:.3f},{p.lmax:.3f}]  "
+                f"r {c.r0:.3f},{c.r1:.3f}->{p.r0:.3f},{p.r1:.3f}  "
+                f"LR {c.lengthrange[0]:.4f},{c.lengthrange[1]:.4f}"
+                f"->{p.lengthrange_lo:.4f},{p.lengthrange_hi:.4f}  "
+                f"L0 {c.l0_implied:.4f}->{p.l0_implied:.4f}"
+            )
+        if len(props) > 10:
+            print(f"  ... +{len(props) - 10} more")
+        payload["proposals"] = [
+            {
+                "name": p.name,
+                "lmin": p.lmin,
+                "lmax": p.lmax,
+                "r0": p.r0,
+                "r1": p.r1,
+                "lengthrange": [p.lengthrange_lo, p.lengthrange_hi],
+                "l0_implied": p.l0_implied,
+                "current": asdict(p.current),
+                "path": asdict(p.path),
+            }
+            for p in props
+        ]
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2))
+        print(f"\nwrote {args.json_out}")
+
+    # Non-zero exit when verify finds issues (useful for CI)
+    if args.verify_only and violations:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_muscle_length_params.py
+++ b/tests/test_muscle_length_params.py
@@ -7,8 +7,8 @@ These tests document calibration consistency problems in the shipped models:
 * ``gainprm[0]``/``[1]`` (operating range) can fall outside ``[lmin, lmax]``.
 * Measured musculotendon path can fall outside declared ``lengthrange``.
 
-They are **excluded** from the default CI pytest invocation and run only from the
-``muscle-params`` workflow job when model XML (or these files) change.
+**Not part of the default PR CI gate.** Run manually or via the pre-release job in
+``.github/workflows/publish.yml`` before cutting a release.
 
 Recalculation helper: ``tests/recalc_from_fl_bounds.py``.
 """

--- a/tests/test_muscle_length_params.py
+++ b/tests/test_muscle_length_params.py
@@ -1,0 +1,115 @@
+"""Verify muscle lengthrange / operating range / FL bounds (lmin, lmax).
+
+These tests document calibration consistency problems in the shipped models:
+
+* ``gainprm[4]``/``[5]`` (FL ``lmin``/``lmax``) are often a shared default per model
+  rather than per-muscle values (especially arm + torso).
+* ``gainprm[0]``/``[1]`` (operating range) can fall outside ``[lmin, lmax]``.
+* Measured musculotendon path can fall outside declared ``lengthrange``.
+
+They are **excluded** from the default CI pytest invocation and run only from the
+``muscle-params`` workflow job when model XML (or these files) change.
+
+Recalculation helper: ``tests/recalc_from_fl_bounds.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from recalc_from_fl_bounds import (
+    MuscleParams,
+    PathSample,
+    fl_bound_diversity,
+    operating_band_from_fl,
+    propose_for_model,
+    recalc_from_fl_bounds,
+    verify_model,
+)
+
+# Models to audit when their assets change
+MODELS = ("myoarm_r", "myolegs", "myotorso")
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_operating_range_within_fl_bounds(model_name: str):
+    """r0/r1 must lie inside [lmin, lmax] (MuJoCo FL domain)."""
+    violations = [v for v in verify_model(model_name) if v.kind == "operating_outside_fl"]
+    if violations:
+        lines = [f"{v.name}: {v.detail}" for v in violations[:30]]
+        more = f"\n  ... +{len(violations) - 30} more" if len(violations) > 30 else ""
+        pytest.fail(
+            f"{model_name}: {len(violations)} muscles have operating range outside FL bounds:\n  " + "\n  ".join(lines) + more
+        )
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_path_within_lengthrange(model_name: str):
+    """Primary-joint MTU path must lie inside declared lengthrange."""
+    violations = [v for v in verify_model(model_name) if v.kind == "path_outside_lengthrange"]
+    if violations:
+        lines = [f"{v.name}: {v.detail}" for v in violations[:30]]
+        more = f"\n  ... +{len(violations) - 30} more" if len(violations) > 30 else ""
+        pytest.fail(f"{model_name}: {len(violations)} muscles have path outside lengthrange:\n  " + "\n  ".join(lines) + more)
+
+
+@pytest.mark.parametrize(
+    "model_name,min_unique",
+    [
+        # Arm/torso currently share one or two FL defaults — fail to surface the issue.
+        ("myoarm_r", 5),
+        ("myotorso", 5),
+        # Legs already vary; require at least a handful of distinct pairs.
+        ("myolegs", 5),
+    ],
+)
+def test_fl_lmin_lmax_not_a_single_shared_default(model_name: str, min_unique: int):
+    """Per-muscle FL (lmin,lmax) should not collapse to one shared default.
+
+    If myoconverter (or hand authoring) never wrote optimized FL bounds into
+    ``gainprm[4]``/``[5]``, every muscle keeps the same ``(lmin, lmax)``.
+    """
+    summary = fl_bound_diversity(model_name)
+    n_unique = summary["n_unique_fl_bounds"]
+    if n_unique < min_unique:
+        top = list(summary["counts"].items())[:3]
+        pytest.fail(
+            f"{model_name}: only {n_unique} unique (lmin,lmax) pair(s) across "
+            f"{summary['n_actuators']} actuators (need >= {min_unique}). "
+            f"Top counts: {top}. "
+            "Use tests/recalc_from_fl_bounds.py after setting per-muscle FL bounds."
+        )
+
+
+def test_recalc_from_fl_bounds_places_operating_band_inside_fl():
+    """Unit check: proposed r0/r1 lie in [lmin,lmax] and LR spans the path."""
+    current = MuscleParams(
+        name="dummy",
+        lengthrange=(0.10, 0.20),
+        r0=0.2,
+        r1=1.9,
+        lmin=0.0,
+        lmax=2.0,
+        fmax=100.0,
+        l0_implied=0.1 / 1.7,
+    )
+    path = PathSample(joint="j", mtu_min=0.12, mtu_max=0.18)
+    prop = recalc_from_fl_bounds(path, current, lmin=0.5, lmax=1.6, band_frac=0.15)
+    assert prop.lmin == 0.5 and prop.lmax == 1.6
+    assert prop.lmin - 1e-9 <= prop.r0 < prop.r1 <= prop.lmax + 1e-9
+    assert prop.lengthrange_hi > prop.lengthrange_lo
+    assert prop.lengthrange_lo <= path.mtu_min
+    assert prop.lengthrange_hi >= path.mtu_max
+
+
+def test_operating_band_from_fl_contains_one_when_possible():
+    r0, r1 = operating_band_from_fl(0.5, 1.6, band_frac=0.15)
+    assert r0 < 1.0 < r1
+    assert 0.5 <= r0 < r1 <= 1.6
+
+
+def test_propose_for_model_smoke_myoarm_single_muscle():
+    props = propose_for_model("myoarm_r", muscle="DELT1", lmin=0.5, lmax=1.6)
+    assert len(props) == 1
+    p = props[0]
+    assert p.name == "DELT1"
+    assert 0.5 <= p.r0 < p.r1 <= 1.6

--- a/tests/test_muscle_length_params.py
+++ b/tests/test_muscle_length_params.py
@@ -7,8 +7,7 @@ These tests document calibration consistency problems in the shipped models:
 * ``gainprm[0]``/``[1]`` (operating range) can fall outside ``[lmin, lmax]``.
 * Measured musculotendon path can fall outside declared ``lengthrange``.
 
-**Not part of the default PR CI gate.** Run manually or via the pre-release job in
-``.github/workflows/publish.yml`` before cutting a release.
+**Not part of CI.** Run manually before cutting a release or when auditing calibration.
 
 Recalculation helper: ``tests/recalc_from_fl_bounds.py``.
 """

--- a/tests/test_muscle_length_params.py
+++ b/tests/test_muscle_length_params.py
@@ -54,7 +54,11 @@ def test_path_within_lengthrange(model_name: str):
 @pytest.mark.parametrize(
     "model_name,min_unique",
     [
-        # Arm/torso currently share one or two FL defaults — fail to surface the issue.
+        # Arm/torso have historically shared one or two FL defaults across most
+        # actuators; #123 individually calibrates the worst-inflated subset (still
+        # leaves many muscles on the shared default). This threshold is a
+        # regression guard against collapsing back to a single shared default,
+        # not a claim about full per-muscle calibration.
         ("myoarm_r", 5),
         ("myotorso", 5),
         # Legs already vary; require at least a handful of distinct pairs.


### PR DESCRIPTION
## Summary

* Adds `tests/recalc_from_fl_bounds.py`: verify + recalculate `lengthrange` and operating range (`gainprm[0]`/`[1]`) from FL bounds (`lmin`/`lmax` = `gainprm[4]`/`[5]`) and measured MTU path.
* Adds `tests/test_muscle_length_params.py` to assert operating band ⊆ FL domain, path ⊆ `lengthrange`, and that `(lmin,lmax)` is not a single shared default per model.
* Excludes these audits from CI entirely (same pattern as equivalence and bimanual symmetry). Documented in the fast gate so contributors do not hit expected FL-bound failures.

**Intent of this PR:** ship a standing diagnostic tool that surfaces muscle-calibration gaps (shared FL defaults, operating range outside the FL domain, path outside the declared `lengthrange`) without failing CI or shipping model XML fixes itself. Rebased onto current `dev`.

### Relationship to #123 and #124

#123 (anatomical muscle-parameter fixes) and #124 (elastic tendon) both land model XML changes; this PR is independent of both and can merge in any order relative to them — it only adds test infrastructure.

Ran this audit against #123's branch directly to confirm the two complement each other correctly:

* #123 individually calibrates `(lmin, lmax)` for every muscle whose anatomical refit pushed its operating range outside the previous shared default — `test_operating_range_within_fl_bounds` passes clean on #123 for every model.
* As a side effect, `myoarm_r` and `myotorso` also now clear `test_fl_lmin_lmax_not_a_single_shared_default` (both were failing on `dev`). The comment on that test has been updated to describe it as an ongoing regression guard rather than a one-time gap, since most muscles in those two models are still on the shared default and only the #123-flagged subset was individually recalibrated.
* `test_path_within_lengthrange` still fails, identically, on `dev` and on #123 — a separate, unresolved gap (measured MTU path exceeding the declared `lengthrange` for a number of muscles) that neither #123 nor #124 addresses. Left open for future work; this PR's job is to keep it visible, not to fix it.

### Recalc utility

```bash
uv run python tests/recalc_from_fl_bounds.py --model myoarm_r --verify-only
uv run python tests/recalc_from_fl_bounds.py --model myoarm_r --lmin 0.5 --lmax 1.6
```

## Test plan

* [x] Unit smoke tests for recalc helper pass
* [x] Default CI suite stays green (audit ignored)
* [x] Fast gate documents `--ignore=tests/test_muscle_length_params.py`
* [x] Manual: `uv run pytest tests/test_muscle_length_params.py -v` shows clear FL-diversity messages
* [x] Verified against #123's branch: no new failures introduced, two `myoarm_r`/`myotorso` shared-default failures resolved, `test_path_within_lengthrange` remains as the one open gap