### PR TITLE
Simplify model building logic, prioritise spec over model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ tests/output/
 .idea/
 .vscode/
 .claude/
+
+
+# Generated models
+myo_sim/models/

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -95,6 +95,8 @@ def _legs26_spec():
     return load_legs26_spec()
 
 
+# TODO: there should be a myohand_l alias, which should work with load. Also a given name (myolegs) should refer to the
+#       same model consistently.
 # Maps fragment names to zero-arg callables returning an editable (uncompiled)
 # MjSpec, with no torso scaffold.  Used by downstream consumers (e.g. myosuite
 # ModelBuilder, assist_sim) so that attaching a fragment routes through the compose
@@ -120,35 +122,39 @@ def load(name: str) -> tuple:
     left-hand-only MjSpec builder, use FRAGMENT_SPEC_BUILDERS["myohand_l"].
     """
     import mujoco
+    model = load_model(name)
+    return model, mujoco.MjData(model)
 
-    from myo_sim.build.compose import ALIASES, build_model
+def load_model(name: str) -> tuple:
+    spec = load_spec(name)
+    model = spec.compile()
+    return model
+
+
+def load_spec(name: str) -> "mujoco.MjSpec":
+    """Build and return the uncompiled MjSpec for a named model.
+
+    Unlike load(), this stops at the editable MjSpec so downstream consumers
+    (e.g. assist_sim) can edit the model -- attach devices, delete bodies, add
+    actuators -- before compiling it themselves.
+    """
+    import mujoco
+
+    from myo_sim.build.compose import ALIASES, build_spec
 
     composed_models = _composed_models()
     if name in composed_models:
         # Legacy aliases (e.g. hand, myohand, myoarm) resolve to a registry entry.
         composed_name = ALIASES.get(name, name)
-        model = build_model(composed_name)
-        return model, mujoco.MjData(model)
+        spec = build_spec(composed_name)
+        return spec
 
     if name not in REGISTRY:
         available = sorted(composed_models | frozenset(REGISTRY))
         raise ValueError(f"Unknown model {name!r}. Available: {available}")
 
-    model = mujoco.MjModel.from_xml_path(str(get_xml_path(name)))
-    return model, mujoco.MjData(model)
-
-
-def build_spec(name: str) -> "mujoco.MjSpec":
-    """Return the uncompiled MjSpec for a composed model (mirror of load()).
-
-    Unlike load(), this stops at the editable MjSpec so downstream consumers
-    (e.g. assist_sim) can edit the model -- attach devices, delete bodies, add
-    actuators -- before compiling it themselves. Covers the generated composed
-    specs (myoarms, myotorso, myolegs, myolegs26, myofullbody).
-    """
-    from myo_sim.build.compose import build_generated_model_spec
-
-    return build_generated_model_spec(name)
+    spec = mujoco.MjSpec.from_file(str(get_xml_path(name)))
+    return spec
 
 
 def get_path(rel: str) -> Path:

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -122,8 +122,10 @@ def load(name: str) -> tuple:
     left-hand-only MjSpec builder, use FRAGMENT_SPEC_BUILDERS["myohand_l"].
     """
     import mujoco
+
     model = load_model(name)
     return model, mujoco.MjData(model)
+
 
 def load_model(name: str) -> tuple:
     spec = load_spec(name)

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -497,7 +497,6 @@ def build_fullbody_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     return torso
 
 
-
 def build_legs_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_passive_torso_spec(registration)
     root_body = find_body(torso, "Full Body")
@@ -506,7 +505,6 @@ def build_legs_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso.attach(load_legs_spec(), prefix="", suffix="", frame=legs_frame)
 
     return torso
-
 
 
 def build_legs26_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -711,7 +711,7 @@ def main() -> None:
             print(f"generated: {output_path}")
         return
 
-    model = build_model(args.model)
+    model = build_spec(args.model).compile()
     registration = MODEL_REGISTRY[args.model]
     print(f"compiled {args.model}: nbody={model.nbody}, njnt={model.njnt}, nu={model.nu}")
     print(f"description: {registration.description}")

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -1,6 +1,6 @@
 """MjSpec.attach()-based composition of the myo_sim musculoskeletal models.
 
-This is the production build pipeline: ``build_model(name)`` is the public entry
+This is the production build pipeline: ``build_spec(name)`` is the public entry
 point and every composed model in ``MODEL_REGISTRY`` is compiled through it.
 
 Run from the repository root:
@@ -118,6 +118,10 @@ class BuildStrategy(str, Enum):
 
 @dataclass(frozen=True)
 class ModelRegistration:
+    # TODO: too specific fields. The concept of a left arm is not always relevant, and should be handled
+    #       by the builder of the relevant subspec. Similarly, not all models should  have fields associated with
+    #       contacts specific to the arm, or the body. Each subspec/submodel should have a relevant and specific config,
+    #       with generalist fields, and perhaps some specific ones from a childclass of ModelRegistration.
     name: str
     build_strategy: BuildStrategy
     left_arm_strategy: str
@@ -285,10 +289,6 @@ def build_torso_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     return load_torso_spec(registration)
 
 
-def build_torso_body_model(registration: ModelRegistration) -> mujoco.MjModel:
-    return build_torso_body_spec(registration).compile()
-
-
 def make_torso_passive(torso: mujoco.MjSpec) -> None:
     """Remove torso dynamics so the anatomical torso acts as a fixed scaffold."""
     for equality in list(torso.equalities):
@@ -420,15 +420,11 @@ def build_arms_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     return torso
 
 
-def build_arms_body_model(registration: ModelRegistration) -> mujoco.MjModel:
-    return build_arms_body_spec(registration).compile()
-
-
-def build_right_arm_body_model(registration: ModelRegistration) -> mujoco.MjModel:
+def build_right_arm_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_passive_torso_spec(registration)
     torso.attach(load_right_arm_spec(), prefix="", suffix="", site=find_site(torso, RIGHT_ARM_ATTACH_SITE))
 
-    return torso.compile()
+    return torso
 
 
 def load_right_hand_from_arm_spec() -> mujoco.MjSpec:
@@ -446,7 +442,7 @@ def load_left_hand_from_arm_spec() -> mujoco.MjSpec:
     return hand
 
 
-def build_right_hand_from_arm_model(registration: ModelRegistration) -> mujoco.MjModel:
+def build_right_hand_from_arm_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_passive_torso_spec(registration)
     torso.attach(load_right_hand_from_arm_spec(), prefix="", suffix="", site=find_site(torso, RIGHT_ARM_ATTACH_SITE))
     add_contact_pairs(
@@ -454,15 +450,15 @@ def build_right_hand_from_arm_model(registration: ModelRegistration) -> mujoco.M
         HAND_CONTACTS_XML,
         include_pair=lambda pair: pair_is_supported(pair, include_left_arm_contacts=False),
     )
-    return torso.compile()
+    return torso
 
 
-def build_both_hands_from_arm_model(registration: ModelRegistration) -> mujoco.MjModel:
+def build_both_hands_from_arm_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_passive_torso_spec(registration)
     torso.attach(load_right_hand_from_arm_spec(), prefix="", suffix="", site=find_site(torso, RIGHT_ARM_ATTACH_SITE))
     torso.attach(load_left_hand_from_arm_spec(), prefix="", suffix="", site=find_site(torso, LEFT_ARM_ATTACH_SITE))
     add_contact_pairs(torso, HAND_CONTACTS_XML)
-    return torso.compile()
+    return torso
 
 
 def load_left_arm_spec(registration: ModelRegistration) -> mujoco.MjSpec | None:
@@ -473,7 +469,7 @@ def load_left_arm_spec(registration: ModelRegistration) -> mujoco.MjSpec | None:
     raise ValueError(f"Unknown left arm strategy for {registration.name}: {registration.left_arm_strategy}")
 
 
-def build_torso_arms_model(registration: ModelRegistration) -> mujoco.MjModel:
+def build_torso_arms_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_torso_spec(registration)
     right_arm = load_right_arm_spec()
     left_arm = load_left_arm_spec(registration)
@@ -482,7 +478,7 @@ def build_torso_arms_model(registration: ModelRegistration) -> mujoco.MjModel:
     if left_arm is not None:
         torso.attach(left_arm, prefix="", suffix="", site=find_site(torso, LEFT_ARM_ATTACH_SITE))
 
-    return torso.compile()
+    return torso
 
 
 def build_fullbody_spec(registration: ModelRegistration) -> mujoco.MjSpec:
@@ -501,9 +497,6 @@ def build_fullbody_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     return torso
 
 
-def build_fullbody_model(registration: ModelRegistration) -> mujoco.MjModel:
-    return build_fullbody_spec(registration).compile()
-
 
 def build_legs_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_passive_torso_spec(registration)
@@ -515,9 +508,6 @@ def build_legs_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     return torso
 
 
-def build_legs_body_model(registration: ModelRegistration) -> mujoco.MjModel:
-    return build_legs_body_spec(registration).compile()
-
 
 def build_legs26_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     torso = load_passive_torso_spec(registration)
@@ -528,19 +518,15 @@ def build_legs26_body_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     return torso
 
 
-def build_legs26_body_model(registration: ModelRegistration) -> mujoco.MjModel:
-    return build_legs26_body_spec(registration).compile()
-
-
-def build_torso_abdomen_model(registration: ModelRegistration) -> mujoco.MjModel:
+def build_torso_abdomen_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     abdomen = load_torso_abdomen_spec()
     root_body = find_body(abdomen, "root")
     root_body.pos = registration.root_pos
     root_body.quat = TORSO_ABDOMEN_ROOT_QUAT
-    return abdomen.compile()
+    return abdomen
 
 
-def build_legs_abdomen_model(registration: ModelRegistration) -> mujoco.MjModel:
+def build_legs_abdomen_spec(registration: ModelRegistration) -> mujoco.MjSpec:
     abdomen = load_torso_abdomen_spec()
 
     root_body = find_body(abdomen, "root")
@@ -550,49 +536,31 @@ def build_legs_abdomen_model(registration: ModelRegistration) -> mujoco.MjModel:
     legs_frame = root_body.add_frame(name="legs_attach")
     abdomen.attach(load_legs_spec(), prefix="", suffix="", frame=legs_frame)
 
-    return abdomen.compile()
+    return abdomen
 
 
-BUILDERS = {
-    BuildStrategy.TORSO_BODY: build_torso_body_model,
-    BuildStrategy.TORSO_ARMS: build_torso_arms_model,
-    BuildStrategy.ARMS_BODY: build_arms_body_model,
-    BuildStrategy.RIGHT_ARM_BODY: build_right_arm_body_model,
-    BuildStrategy.RIGHT_HAND: build_right_hand_from_arm_model,
-    BuildStrategy.BOTH_HANDS: build_both_hands_from_arm_model,
-    BuildStrategy.FULLBODY: build_fullbody_model,
-    BuildStrategy.LEGS_BODY: build_legs_body_model,
-    BuildStrategy.LEGS26_BODY: build_legs26_body_model,
-    BuildStrategy.TORSO_ABDOMEN: build_torso_abdomen_model,
-    BuildStrategy.LEGS_ABDOMEN: build_legs_abdomen_model,
-}
-
-GENERATE_SPEC_BUILDERS = {
-    "myoarms": build_arms_body_spec,
-    "myotorso": build_torso_body_spec,
-    "myolegs": build_legs_body_spec,
-    "myolegs26": build_legs26_body_spec,
-    "myofullbody": build_fullbody_spec,
+SPEC_BUILDERS = {
+    BuildStrategy.TORSO_BODY: build_torso_body_spec,
+    BuildStrategy.TORSO_ARMS: build_torso_arms_spec,
+    BuildStrategy.ARMS_BODY: build_arms_body_spec,
+    BuildStrategy.RIGHT_ARM_BODY: build_right_arm_body_spec,
+    BuildStrategy.RIGHT_HAND: build_right_hand_from_arm_spec,
+    BuildStrategy.BOTH_HANDS: build_both_hands_from_arm_spec,
+    BuildStrategy.FULLBODY: build_fullbody_spec,
+    BuildStrategy.LEGS_BODY: build_legs_body_spec,
+    BuildStrategy.LEGS26_BODY: build_legs26_body_spec,
+    BuildStrategy.TORSO_ABDOMEN: build_torso_abdomen_spec,
+    BuildStrategy.LEGS_ABDOMEN: build_legs_abdomen_spec,
 }
 
 
-def build_model(model_name: str) -> mujoco.MjModel:
+def build_spec(model_name: str) -> mujoco.MjSpec:
     try:
         registration = MODEL_REGISTRY[model_name]
     except KeyError as exc:
         available = ", ".join(sorted(MODEL_REGISTRY))
         raise ValueError(f"Unknown model selection: {model_name}. Available: {available}") from exc
-    return BUILDERS[registration.build_strategy](registration)
-
-
-def build_generated_model_spec(model_name: str) -> mujoco.MjSpec:
-    try:
-        registration = MODEL_REGISTRY[model_name]
-        builder = GENERATE_SPEC_BUILDERS[model_name]
-    except KeyError as exc:
-        available = ", ".join(GENERATE_XML_TARGETS)
-        raise ValueError(f"Cannot generate XML for model selection: {model_name}. Available: {available}") from exc
-    return builder(registration)
+    return SPEC_BUILDERS[registration.build_strategy](registration)
 
 
 def unwrap_nested_classless_defaults(element: ET.Element) -> None:
@@ -695,7 +663,7 @@ def generate_xml_files(output_root: Path = ROOT) -> list[Path]:
     output_paths: list[Path] = []
     for model_name, rel_path in GENERATE_XML_TARGETS.items():
         output_path = output_root / rel_path
-        spec = build_generated_model_spec(model_name)
+        spec = build_spec(model_name)
         write_spec_xml(spec, output_path)
         output_paths.append(output_path)
     return output_paths

--- a/myo_sim/build/utils.py
+++ b/myo_sim/build/utils.py
@@ -333,7 +333,9 @@ def build_mirrored_child_xml(
     root_site_name: str,
     rules: MirrorRules | None = None,
 ) -> str:
-    """Build a mirrored MJCF child XML from right-side arm component files."""
+    """
+    TODO: Mirroring is feasible to do via MjSpec. Let's avoid editing xmls unless absolutely necessary.
+    Build a mirrored MJCF child XML from right-side arm component files."""
     if rules is None:
         rules = MirrorRules()
     root = ET.Element("mujoco", {"model": model_name})

--- a/tests/debug_muscle_bimanual.py
+++ b/tests/debug_muscle_bimanual.py
@@ -35,9 +35,9 @@ JOINT_SUFFIX = {"right": "_r", "left": "_l"}
 
 
 def load_model(model_name: str):
-    from myo_sim.build.compose import build_model
+    from myo_sim import load_model
 
-    return build_model(model_name)
+    return load_model(model_name)
 
 
 def load_equality_map(model, model_name: str):

--- a/tests/test_bimanual_muscle_symmetry.py
+++ b/tests/test_bimanual_muscle_symmetry.py
@@ -6,12 +6,12 @@ from muscle_symmetry_checks import (
     discover_bilateral_suffix_pairs,
 )
 
-from myo_sim.build.compose import build_model
+from myo_sim import load_model
 
 
 @pytest.fixture(scope="module")
 def bimanual_model_context():
-    model = build_model("myoarms")
+    model = load_model("myoarms")
     data = mujoco.MjData(model)
     eq_map = parse_model_joint_equalities(model)
     return model, data, eq_map

--- a/tests/test_build_registry.py
+++ b/tests/test_build_registry.py
@@ -9,6 +9,7 @@ from myo_sim.build.compose import ALIASES, MODEL_REGISTRY, BuildStrategy, ModelR
 from myo_sim import load_model
 import myo_sim
 
+
 def test_aliases_resolve_to_registered_models():
     unknown = {target for target in ALIASES.values() if target not in MODEL_REGISTRY}
 

--- a/tests/test_build_registry.py
+++ b/tests/test_build_registry.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import mujoco
 
 from myo_sim.build import compose
-from myo_sim.build.compose import ALIASES, MODEL_REGISTRY, BuildStrategy, ModelRegistration, build_model
-
+from myo_sim.build.compose import ALIASES, MODEL_REGISTRY, BuildStrategy, ModelRegistration
+from myo_sim import load_model
+import myo_sim
 
 def test_aliases_resolve_to_registered_models():
     unknown = {target for target in ALIASES.values() if target not in MODEL_REGISTRY}
@@ -48,7 +49,7 @@ def test_myoarms_uses_default_root_position():
 
 def test_every_registered_model_includes_scene_floor():
     for name in MODEL_REGISTRY:
-        model = build_model(name)
+        model = load_model(name)
 
         assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor") >= 0, name
 
@@ -92,14 +93,14 @@ def test_generate_xml_files_writes_base_model_outputs(tmp_path, monkeypatch):
         spec_calls.append(model_name)
         return FakeSpec(model_name)
 
-    def fail_build_model(model_name):
+    def fail_load_model(model_name):
         raise AssertionError(f"generate_xml_files should build specs directly, not compiled models: {model_name}")
 
     def fail_save_last_xml(path, model):
         raise AssertionError("generate_xml_files should use MjSpec.to_xml(), not mj_saveLastXML()")
 
-    monkeypatch.setattr(compose, "build_generated_model_spec", fake_build_generated_model_spec, raising=False)
-    monkeypatch.setattr(compose, "build_model", fail_build_model)
+    monkeypatch.setattr(compose, "build_spec", fake_build_generated_model_spec, raising=False)
+    monkeypatch.setattr(myo_sim, "load_model", fail_load_model)
     monkeypatch.setattr(compose.mujoco, "mj_saveLastXML", fail_save_last_xml)
 
     output_paths = compose.generate_xml_files(tmp_path)
@@ -156,7 +157,7 @@ def test_generated_xml_keeps_floor_collision_enabled(tmp_path):
 
 
 def test_myolegs26_knee_reset_uses_baked_tibia_offsets():
-    model = build_model("myolegs26")
+    model = load_model("myolegs26")
     knee_translation_joints = (
         "knee_r_translation1",
         "knee_r_translation2",
@@ -182,7 +183,7 @@ def test_myolegs26_knee_reset_uses_baked_tibia_offsets():
 
 
 def test_myolegs26_loads_assembled_at_qpos0():
-    model = build_model("myolegs26")
+    model = load_model("myolegs26")
     data = mujoco.MjData(model)
     mujoco.mj_forward(model, data)
 
@@ -207,7 +208,7 @@ def test_generated_xml_preserves_geom_collision_flags(tmp_path):
     output_paths = compose.generate_xml_files(tmp_path)
 
     for model_name, output_path in zip(compose.GENERATE_XML_TARGETS, output_paths):
-        built_model = build_model(model_name)
+        built_model = load_model(model_name)
         generated_model = mujoco.MjModel.from_xml_path(str(output_path))
 
         assert list(generated_model.geom_contype) == list(built_model.geom_contype), output_path

--- a/tests/test_build_registry.py
+++ b/tests/test_build_registry.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import mujoco
 
+import myo_sim
+from myo_sim import load_model
 from myo_sim.build import compose
 from myo_sim.build.compose import ALIASES, MODEL_REGISTRY, BuildStrategy, ModelRegistration
-from myo_sim import load_model
-import myo_sim
 
 
 def test_aliases_resolve_to_registered_models():

--- a/tests/test_chest_ownership.py
+++ b/tests/test_chest_ownership.py
@@ -4,7 +4,7 @@ import mujoco
 import pytest
 
 import myo_sim
-from myo_sim.build.compose import build_model
+from myo_sim import load_spec
 
 
 def body_id(model, name: str) -> int:
@@ -27,7 +27,7 @@ def test_chest_scaffold_is_torso_owned_not_arm_owned():
 
 @pytest.mark.parametrize("model_name", ("myoarms", "myotorso_arms", "myofullbody"))
 def test_composed_arm_models_do_not_mirror_torso_chest(model_name):
-    model = build_model(model_name)
+    model = load_spec(model_name).compile()
 
     assert body_id(model, "chest_r") >= 0
     assert body_id(model, "cervical_spine") >= 0

--- a/tests/test_legs_abdomen_build.py
+++ b/tests/test_legs_abdomen_build.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import mujoco
 
-from myo_sim.build.compose import build_model
+from myo_sim import load_model
 
 ROOT = Path(__file__).resolve().parents[1]
 TORSO_ASSETS = ROOT / "myo_sim" / "models" / "torso" / "assets"
@@ -17,7 +17,7 @@ def joint_names(model) -> set[str]:
 
 
 def test_myotorso_abdomen_builds_from_registered_spec():
-    model = build_model("myotorso_abdomen")
+    model = load_model("myotorso_abdomen")
 
     assert id_for(model, mujoco.mjtObj.mjOBJ_BODY, "sacrum") >= 0
     assert id_for(model, mujoco.mjtObj.mjOBJ_BODY, "lumbar5") >= 0
@@ -27,13 +27,13 @@ def test_myotorso_abdomen_builds_from_registered_spec():
 
 
 def test_myotorso_abdomen_locks_all_but_base_lumbar5_joints():
-    model = build_model("myotorso_abdomen")
+    model = load_model("myotorso_abdomen")
 
     assert joint_names(model) == {"flex_extension", "lat_bending", "axial_rotation"}
 
 
 def test_myotorso_chain_contains_simple_abdomen_compatibility_points():
-    model = build_model("myotorso_abdomen")
+    model = load_model("myotorso_abdomen")
     required_sites = (
         "ercspn_r_ercspn_r-P1",
         "ercspn_l_ercspn_l-P1",
@@ -72,7 +72,7 @@ def test_myotorso_abdomen_uses_full_torso_assets_and_chain():
 
 
 def test_myolegs_builds_with_passive_torso_scaffold():
-    model = build_model("myolegs")
+    model = load_model("myolegs")
 
     assert id_for(model, mujoco.mjtObj.mjOBJ_BODY, "Full Body") >= 0
     assert id_for(model, mujoco.mjtObj.mjOBJ_BODY, "pelvis") >= 0
@@ -83,7 +83,7 @@ def test_myolegs_builds_with_passive_torso_scaffold():
 
 
 def test_myolegs_abdomen_builds_from_registered_spec():
-    model = build_model("myolegs_abdomen")
+    model = load_model("myolegs_abdomen")
 
     assert id_for(model, mujoco.mjtObj.mjOBJ_BODY, "pelvis") >= 0
     assert id_for(model, mujoco.mjtObj.mjOBJ_BODY, "sacrum") >= 0

--- a/tests/test_mirror_symmetry.py
+++ b/tests/test_mirror_symmetry.py
@@ -2,7 +2,7 @@ import mujoco
 import numpy as np
 import pytest
 
-from myo_sim.build.compose import build_model
+from myo_sim import load_model
 
 ARM_BODY_PAIRS = (
     "clavicle",
@@ -48,7 +48,7 @@ def mirror_plane_x(model, data):
 
 @pytest.mark.parametrize("model_name", ("myoarms", "myofullbody"))
 def test_mirrored_arm_body_centers_reflect_across_sagittal_plane(model_name):
-    model = build_model(model_name)
+    model = load_model(model_name)
     data = mujoco.MjData(model)
     mujoco.mj_forward(model, data)
     plane_x = mirror_plane_x(model, data)
@@ -70,7 +70,7 @@ def test_mirrored_arm_body_centers_reflect_across_sagittal_plane(model_name):
 
 @pytest.mark.parametrize("model_name", ("myoarms", "myofullbody"))
 def test_mirrored_arm_joint_axes_reflect_across_sagittal_plane(model_name):
-    model = build_model(model_name)
+    model = load_model(model_name)
 
     for base_name in ARM_JOINT_PAIRS:
         right = joint_id(model, f"{base_name}_r")

--- a/tests/test_model_stability.py
+++ b/tests/test_model_stability.py
@@ -9,9 +9,8 @@ import mujoco
 import numpy as np
 import pytest
 
-from myo_sim.build.compose import MODEL_REGISTRY
 from myo_sim import load_model
-
+from myo_sim.build.compose import MODEL_REGISTRY
 
 STEPS = 50
 

--- a/tests/test_model_stability.py
+++ b/tests/test_model_stability.py
@@ -12,6 +12,7 @@ import pytest
 from myo_sim.build.compose import MODEL_REGISTRY
 from myo_sim import load_model
 
+
 STEPS = 50
 
 

--- a/tests/test_model_stability.py
+++ b/tests/test_model_stability.py
@@ -9,14 +9,15 @@ import mujoco
 import numpy as np
 import pytest
 
-from myo_sim.build.compose import MODEL_REGISTRY, build_model
+from myo_sim.build.compose import MODEL_REGISTRY
+from myo_sim import load_model
 
 STEPS = 50
 
 
 @pytest.mark.parametrize("name", sorted(MODEL_REGISTRY))
 def test_model_steps_without_going_nonfinite(name):
-    model = build_model(name)
+    model = load_model(name)
     data = mujoco.MjData(model)
 
     for _ in range(STEPS):

--- a/tests/test_package_install.py
+++ b/tests/test_package_install.py
@@ -28,5 +28,5 @@ def test_load_myolegs():
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor") >= 0
 
 
-def test_build_compose_import():
-    from myo_sim.build.compose import build_model  # noqa: F401
+def test_load_import():
+    from myo_sim import load  # noqa: F401

--- a/tests/test_passive_torso_build.py
+++ b/tests/test_passive_torso_build.py
@@ -1,6 +1,6 @@
 import mujoco
 
-from myo_sim.build.compose import build_model
+from myo_sim import load_model
 
 
 def id_for(model, object_type, name: str) -> int:
@@ -8,7 +8,7 @@ def id_for(model, object_type, name: str) -> int:
 
 
 def test_myoarms_uses_passive_anatomical_torso_with_arm_controls_only():
-    model = build_model("myoarms")
+    model = load_model("myoarms")
 
     assert id_for(model, mujoco.mjtObj.mjOBJ_GEOM, "torso_geom_13") >= 0
     assert id_for(model, mujoco.mjtObj.mjOBJ_GEOM, "Chest_ellipsoid_r") >= 0
@@ -21,7 +21,7 @@ def test_myoarms_uses_passive_anatomical_torso_with_arm_controls_only():
 
 
 def test_myoarm_r_uses_passive_anatomical_torso_with_right_arm_only():
-    model = build_model("myoarm_r")
+    model = load_model("myoarm_r")
 
     assert id_for(model, mujoco.mjtObj.mjOBJ_GEOM, "torso_geom_13") >= 0
     assert id_for(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "DELT1") >= 0

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import mujoco
 
 import myo_sim
-from myo_sim.build.compose import build_model
+from myo_sim import load_model
 
 model_paths = [
     "scene/myosuite_scene_noPedestal.xml",
@@ -59,7 +59,7 @@ class TestMuscleMimicFullBody(unittest.TestCase):
 
     def _load(self, rel_path):
         if rel_path == "myofullbody":
-            return build_model("myofullbody")
+            return load_model("myofullbody")
         return mujoco.MjModel.from_xml_path(str(myo_sim.MODELS_DIR / rel_path))
 
     def test_myofullbody_joints(self):
@@ -101,7 +101,7 @@ class TestMuscleMimicFullBody(unittest.TestCase):
         for path, name in parts:
             fullpath = myo_sim.MODELS_DIR / path
             if path in {"myofullbody", "myotorso_arm_r", "myotorso"}:
-                m = build_model(path)
+                m = load_model(path)
                 print(f"  {name:30s}  njnt={m.njnt:4d}  nu={m.nu:4d}")
             elif fullpath.exists():
                 m = mujoco.MjModel.from_xml_path(str(fullpath))


### PR DESCRIPTION
This PR includes some logical simplification to model construction, specifically there should be more unified access to specs independent whether they are preexisting models or generated ones. I removed some occasions where specs were compiled unnecessarily early. The biggest change is that the builder registry now tracks spec builders instead of model builders (best to keep specs for as long as possible, as its much easier to compile later then to try to recover the spec).


Also, added a line in .gitignore to avoid accidental commits of generated xmls.
