### PR TITLE
Add optional site_pos_overrides to build_spec/load_spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/MyoHub/myo_sim/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/MyoHub/myo_sim/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue.svg)](pyproject.toml)
+[![PyPI](https://img.shields.io/pypi/v/myo-sim)](https://pypi.org/project/myo-sim/)
 
 MyoSim is the MuJoCo musculoskeletal model library used by [MyoSuite](https://github.com/facebookresearch/myoSuite).
 It provides anatomically detailed XML models of the human arm, leg, torso, and hand,
@@ -51,11 +52,8 @@ This writes loadable XML files for `myoarms`, `myotorso`, `myolegs`, `myolegs26`
 ## Install
 
 ```bash
-pip install git+https://github.com/MyoHub/myo_sim.git@dev
+pip install myo-sim
 ```
-
-Note: the PyPI package `myo-sim` currently points to an older incompatible version.
-Use the git install above until a new release is published.
 
 ## Quickstart
 

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -8,6 +8,8 @@ from myo_sim.fragments import FragmentRegistry as FragmentRegistry
 if TYPE_CHECKING:
     import mujoco
 
+    from myo_sim.build.compose import CollisionMode
+
 try:
     __version__ = version("myo-sim")
 except PackageNotFoundError:
@@ -133,7 +135,11 @@ def load_model(name: str) -> tuple:
     return model
 
 
-def load_spec(name: str, site_pos_overrides: dict[str, tuple[float, float, float]] | None = None) -> "mujoco.MjSpec":
+def load_spec(
+    name: str,
+    site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
+    collision_mode: "CollisionMode" = "full",
+) -> "mujoco.MjSpec":
     """Build and return the uncompiled MjSpec for a named model.
 
     Unlike load(), this stops at the editable MjSpec so downstream consumers
@@ -148,6 +154,15 @@ def load_spec(name: str, site_pos_overrides: dict[str, tuple[float, float, float
             packaged static-XML fragments. Lets a downstream consumer adjust
             a handful of attachment sites (e.g. project-specific pelvis
             positioning) without forking the underlying chain XML.
+        collision_mode: "full" (default, unchanged behavior) keeps every
+            per-bone collision geom from the #111 mjspec refactor enabled.
+            "coarse" disables collision on the forearm/finger/thumb bone
+            geoms, restoring the pre-#111 convention where only the
+            palm/metacarpal skin geoms are collidable -- see
+            myo_sim.build.compose.disable_finger_collision() and
+            https://github.com/MyoHub/myo_sim/issues/127. Only supported for
+            MjSpec-composed models; ignored for packaged static-XML
+            fragments.
     """
     import mujoco
 
@@ -157,7 +172,7 @@ def load_spec(name: str, site_pos_overrides: dict[str, tuple[float, float, float
     if name in composed_models:
         # Legacy aliases (e.g. hand, myohand, myoarm) resolve to a registry entry.
         composed_name = ALIASES.get(name, name)
-        spec = build_spec(composed_name, site_pos_overrides=site_pos_overrides)
+        spec = build_spec(composed_name, site_pos_overrides=site_pos_overrides, collision_mode=collision_mode)
         return spec
 
     if name not in REGISTRY:

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -133,12 +133,21 @@ def load_model(name: str) -> tuple:
     return model
 
 
-def load_spec(name: str) -> "mujoco.MjSpec":
+def load_spec(name: str, site_pos_overrides: dict[str, tuple[float, float, float]] | None = None) -> "mujoco.MjSpec":
     """Build and return the uncompiled MjSpec for a named model.
 
     Unlike load(), this stops at the editable MjSpec so downstream consumers
     (e.g. assist_sim) can edit the model -- attach devices, delete bodies, add
     actuators -- before compiling it themselves.
+
+    Args:
+        name: Registry name or legacy alias (e.g. "myotorso_arms", "hand").
+        site_pos_overrides: Optional mapping of site name to a new local
+            (x, y, z) pos, applied after composition. Only supported for
+            MjSpec-composed models (see ``_composed_models()``); ignored for
+            packaged static-XML fragments. Lets a downstream consumer adjust
+            a handful of attachment sites (e.g. project-specific pelvis
+            positioning) without forking the underlying chain XML.
     """
     import mujoco
 
@@ -148,7 +157,7 @@ def load_spec(name: str) -> "mujoco.MjSpec":
     if name in composed_models:
         # Legacy aliases (e.g. hand, myohand, myoarm) resolve to a registry entry.
         composed_name = ALIASES.get(name, name)
-        spec = build_spec(composed_name)
+        spec = build_spec(composed_name, site_pos_overrides=site_pos_overrides)
         return spec
 
     if name not in REGISTRY:

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -137,7 +137,6 @@ def load_model(name: str) -> tuple:
 
 def load_spec(
     name: str,
-    site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
     collision_mode: "CollisionMode" = "full",
     inertia_floor: float | None = None,
 ) -> "mujoco.MjSpec":
@@ -149,12 +148,6 @@ def load_spec(
 
     Args:
         name: Registry name or legacy alias (e.g. "myotorso_arms", "hand").
-        site_pos_overrides: Optional mapping of site name to a new local
-            (x, y, z) pos, applied after composition. Only supported for
-            MjSpec-composed models (see ``_composed_models()``); ignored for
-            packaged static-XML fragments. Lets a downstream consumer adjust
-            a handful of attachment sites (e.g. project-specific pelvis
-            positioning) without forking the underlying chain XML.
         collision_mode: "full" (default, unchanged behavior) keeps every
             per-bone collision geom from the #111 mjspec refactor enabled.
             "coarse" disables collision on the forearm/finger/thumb bone
@@ -186,7 +179,6 @@ def load_spec(
         composed_name = ALIASES.get(name, name)
         spec = build_spec(
             composed_name,
-            site_pos_overrides=site_pos_overrides,
             collision_mode=collision_mode,
             inertia_floor=inertia_floor,
         )

--- a/myo_sim/__init__.py
+++ b/myo_sim/__init__.py
@@ -139,6 +139,7 @@ def load_spec(
     name: str,
     site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
     collision_mode: "CollisionMode" = "full",
+    inertia_floor: float | None = None,
 ) -> "mujoco.MjSpec":
     """Build and return the uncompiled MjSpec for a named model.
 
@@ -163,6 +164,17 @@ def load_spec(
             https://github.com/MyoHub/myo_sim/issues/127. Only supported for
             MjSpec-composed models; ignored for packaged static-XML
             fragments.
+        inertia_floor: Optional numerical-conditioning floor for
+            auto/mesh-derived body inertia (sets the compiler's
+            ``boundinertia``/``boundmass``). None (default, unchanged
+            behavior) applies no floor. Pass ``0.0001`` to restore the
+            legacy static-XML convention that several small wrist/finger
+            bones in the right-hand fragment relied on for a
+            well-conditioned mass matrix -- see
+            myo_sim.build.compose.build_spec() and
+            https://github.com/MyoHub/myo_sim/issues/128. Only supported for
+            MjSpec-composed models; ignored for packaged static-XML
+            fragments.
     """
     import mujoco
 
@@ -172,7 +184,12 @@ def load_spec(
     if name in composed_models:
         # Legacy aliases (e.g. hand, myohand, myoarm) resolve to a registry entry.
         composed_name = ALIASES.get(name, name)
-        spec = build_spec(composed_name, site_pos_overrides=site_pos_overrides, collision_mode=collision_mode)
+        spec = build_spec(
+            composed_name,
+            site_pos_overrides=site_pos_overrides,
+            collision_mode=collision_mode,
+            inertia_floor=inertia_floor,
+        )
         return spec
 
     if name not in REGISTRY:

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -652,6 +652,7 @@ def build_spec(
     model_name: str,
     site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
     collision_mode: CollisionMode = "full",
+    inertia_floor: float | None = None,
 ) -> mujoco.MjSpec:
     """Build and return the composed, uncompiled MjSpec for a registered model.
 
@@ -668,6 +669,20 @@ def build_spec(
             pre-#111 palm-only collision convention via
             disable_finger_collision(). See
             https://github.com/MyoHub/myo_sim/issues/127.
+        inertia_floor: Optional numerical-conditioning floor for
+            auto/mesh-derived body inertia, applied via the compiler's
+            ``boundinertia`` attribute (MuJoCo clamps a body's principal
+            inertia up to this value, kg*m^2). When set, ``boundmass`` is
+            also set to 0.001 kg, matching the paired value used by the
+            legacy static-XML convention. None (default, unchanged behavior)
+            leaves the compiler defaults (0, i.e. no floor). Several small
+            wrist/finger bones in the right-hand fragment have true
+            auto-computed inertia as low as ~3e-8 kg*m^2, which
+            ``myoarm_r_assets.xml``'s legacy convention floored to 1e-4 via
+            ``compiler boundinertia=".0001" boundmass="0.001"`` for
+            numerical conditioning of the mass matrix; pass
+            ``inertia_floor=0.0001`` to restore that convention. See
+            https://github.com/MyoHub/myo_sim/issues/128.
 
     Returns:
         The composed MjSpec, ready for further edits or spec.compile().
@@ -684,6 +699,43 @@ def build_spec(
         disable_finger_collision(spec)
     elif collision_mode != "full":
         raise ValueError(f"Unknown collision_mode: {collision_mode!r}. Expected 'full' or 'coarse'.")
+    if inertia_floor is not None:
+        apply_inertia_floor(spec, inertia_floor)
+    return spec
+
+
+def apply_inertia_floor(spec: mujoco.MjSpec, inertia_floor: float) -> mujoco.MjSpec:
+    """Set a ``boundinertia``/``boundmass`` compiler floor on every body, in place.
+
+    Composed fragments are built by attaching child MjSpecs (e.g. the
+    right-arm fragment) into a parent spec via ``MjSpec.attach()``. Each
+    attached body retains its originating sub-spec's own ``compiler``
+    settings at compile time, so setting ``spec.compiler.boundinertia`` only
+    on the top-level composed spec has no effect on bodies that came from an
+    attached child fragment -- only on bodies native to the top-level spec
+    (e.g. torso). To reliably apply the floor everywhere, this sets the
+    per-body compiler override on every body in the tree, not just the
+    top-level spec.
+
+    Args:
+        spec: A composed (uncompiled) MjSpec, as returned by build_spec().
+        inertia_floor: Floor value (kg*m^2) for ``boundinertia``.
+            ``boundmass`` is set to 0.001 kg, matching the paired value used
+            by the legacy static-XML convention.
+
+    Returns:
+        The same spec, mutated in place, for convenient chaining.
+    """
+    spec.compiler.boundinertia = inertia_floor
+    spec.compiler.boundmass = 0.001
+
+    def _set_recursive(body: mujoco.MjsBody) -> None:
+        body.compiler.boundinertia = inertia_floor
+        body.compiler.boundmass = 0.001
+        for child in body.bodies:
+            _set_recursive(child)
+
+    _set_recursive(spec.worldbody)
     return spec
 
 

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -24,6 +24,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 import mujoco
 
@@ -575,9 +576,82 @@ def apply_site_pos_overrides(spec: mujoco.MjSpec, site_pos_overrides: dict[str, 
         spec.site(name).pos = pos
 
 
+# Base names (side suffix stripped) of the per-bone forearm/finger/thumb
+# collision geoms introduced in #111. These are the geoms that
+# collision_mode="coarse" disables, restoring the pre-#111 convention where
+# only the palm/metacarpal skin geoms (*mcskin*) are collidable and the
+# forearm/fingers/thumb are pass-through. See
+# https://github.com/MyoHub/myo_sim/issues/127.
+COARSE_COLLISION_DISABLED_GEOM_BASENAMES: tuple[str, ...] = (
+    "humerus_coll",
+    "ulna_coll",
+    "radius_coll",
+    "radius_coll_2",
+    "radius_coll_3",
+    "proximal_thumb_coll",
+    "distal_thumb_coll",
+    "distal_thumb_coll_2",
+    "proxph2_coll",
+    "midph2_coll",
+    "distph2_coll",
+    "proxph3_coll",
+    "midph3_coll",
+    "distph3_coll",
+    "distph3_coll_2",
+    "proxph4_coll",
+    "midph4_coll",
+    "distph4_coll",
+    "distph4_coll_2",
+    "5proxph_coll",
+    "5midph_coll",
+    "5distph_coll",
+    "5distph_coll_2",
+)
+_ARM_SIDE_SUFFIXES: tuple[str, ...] = ("_r", "_l")
+
+CollisionMode = Literal["full", "coarse"]
+
+
+def disable_finger_collision(spec: mujoco.MjSpec) -> mujoco.MjSpec:
+    """Disable per-bone collision on the forearm/finger/thumb chain, in place.
+
+    myo_sim#111 ("Refactor model composition to mjspec-based fragment
+    system") introduced full per-bone collision capsules on every finger
+    segment plus the forearm bones (radius/ulna/humerus) -- a more
+    anatomically faithful contact model, but a physics-breaking change for
+    anything built against the older, coarser convention where only the
+    palm/metacarpal skin geoms (``*mcskin*``) were collidable and the
+    fingers/forearm were pass-through (e.g. myosuite's baoding-balls tasks,
+    which rely on balls resting across fingertips without catching on
+    capsule edges between adjacent phalanx segments). See
+    https://github.com/MyoHub/myo_sim/issues/127.
+
+    Sets ``contype = conaffinity = 0`` on every geom in
+    ``COARSE_COLLISION_DISABLED_GEOM_BASENAMES`` (right and/or left,
+    whichever are present in ``spec``), leaving every other geom --
+    including the palm/metacarpal skin geoms -- untouched. Geoms absent from
+    ``spec`` (e.g. a right-only fragment has no ``_l`` geoms) are silently
+    skipped.
+
+    Args:
+        spec: A composed (uncompiled) MjSpec, as returned by build_spec().
+
+    Returns:
+        The same spec, mutated in place, for convenient chaining.
+    """
+    for base_name in COARSE_COLLISION_DISABLED_GEOM_BASENAMES:
+        for suffix in _ARM_SIDE_SUFFIXES:
+            geom = spec.geom(base_name + suffix)
+            if geom is not None:
+                geom.contype = 0
+                geom.conaffinity = 0
+    return spec
+
+
 def build_spec(
     model_name: str,
     site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
+    collision_mode: CollisionMode = "full",
 ) -> mujoco.MjSpec:
     """Build and return the composed, uncompiled MjSpec for a registered model.
 
@@ -588,6 +662,12 @@ def build_spec(
             consumer adjust a handful of attachment sites (e.g. pelvis
             positioning for a project-specific skeleton) without needing a
             forked copy of the underlying chain XML.
+        collision_mode: "full" (default, unchanged behavior) keeps every
+            collision geom from the #111 refactor enabled. "coarse" disables
+            collision on the forearm/finger/thumb bone geoms, restoring the
+            pre-#111 palm-only collision convention via
+            disable_finger_collision(). See
+            https://github.com/MyoHub/myo_sim/issues/127.
 
     Returns:
         The composed MjSpec, ready for further edits or spec.compile().
@@ -600,6 +680,10 @@ def build_spec(
     spec = SPEC_BUILDERS[registration.build_strategy](registration)
     if site_pos_overrides:
         apply_site_pos_overrides(spec, site_pos_overrides)
+    if collision_mode == "coarse":
+        disable_finger_collision(spec)
+    elif collision_mode != "full":
+        raise ValueError(f"Unknown collision_mode: {collision_mode!r}. Expected 'full' or 'coarse'.")
     return spec
 
 

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -650,7 +650,6 @@ def disable_finger_collision(spec: mujoco.MjSpec) -> mujoco.MjSpec:
 
 def build_spec(
     model_name: str,
-    site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
     collision_mode: CollisionMode = "full",
     inertia_floor: float | None = None,
 ) -> mujoco.MjSpec:
@@ -658,11 +657,6 @@ def build_spec(
 
     Args:
         model_name: Key into MODEL_REGISTRY (e.g. "myotorso_arms").
-        site_pos_overrides: Optional mapping of site name to a new local
-            (x, y, z) pos, applied after composition. Lets a downstream
-            consumer adjust a handful of attachment sites (e.g. pelvis
-            positioning for a project-specific skeleton) without needing a
-            forked copy of the underlying chain XML.
         collision_mode: "full" (default, unchanged behavior) keeps every
             collision geom from the #111 refactor enabled. "coarse" disables
             collision on the forearm/finger/thumb bone geoms, restoring the
@@ -693,8 +687,6 @@ def build_spec(
         available = ", ".join(sorted(MODEL_REGISTRY))
         raise ValueError(f"Unknown model selection: {model_name}. Available: {available}") from exc
     spec = SPEC_BUILDERS[registration.build_strategy](registration)
-    if site_pos_overrides:
-        apply_site_pos_overrides(spec, site_pos_overrides)
     if collision_mode == "coarse":
         disable_finger_collision(spec)
     elif collision_mode != "full":
@@ -704,7 +696,7 @@ def build_spec(
     return spec
 
 
-def apply_inertia_floor(spec: mujoco.MjSpec, inertia_floor: float) -> mujoco.MjSpec:
+def apply_inertia_floor(spec: mujoco.MjSpec, inertia_floor: float, mass_floor=0.001) -> mujoco.MjSpec:
     """Set a ``boundinertia``/``boundmass`` compiler floor on every body, in place.
 
     Composed fragments are built by attaching child MjSpecs (e.g. the
@@ -718,20 +710,21 @@ def apply_inertia_floor(spec: mujoco.MjSpec, inertia_floor: float) -> mujoco.MjS
     top-level spec.
 
     Args:
-        spec: A composed (uncompiled) MjSpec, as returned by build_spec().
-        inertia_floor: Floor value (kg*m^2) for ``boundinertia``.
-            ``boundmass`` is set to 0.001 kg, matching the paired value used
-            by the legacy static-XML convention.
+      spec: A composed (uncompiled) MjSpec, as returned by build_spec().
+      inertia_floor: Floor value (kg*m^2) for ``boundinertia``.
+          ``boundmass``.
+      mass_floor: Floor value (kg) for ``boundmass``. Default value matches
+          old myo_sim models.
 
     Returns:
-        The same spec, mutated in place, for convenient chaining.
+      The same spec, mutated in place, for convenient chaining.
     """
     spec.compiler.boundinertia = inertia_floor
-    spec.compiler.boundmass = 0.001
+    spec.compiler.boundmass = mass_floor
 
     def _set_recursive(body: mujoco.MjsBody) -> None:
         body.compiler.boundinertia = inertia_floor
-        body.compiler.boundmass = 0.001
+        body.compiler.boundmass = mass_floor
         for child in body.bodies:
             _set_recursive(child)
 

--- a/myo_sim/build/compose.py
+++ b/myo_sim/build/compose.py
@@ -552,13 +552,55 @@ SPEC_BUILDERS = {
 }
 
 
-def build_spec(model_name: str) -> mujoco.MjSpec:
+def apply_site_pos_overrides(spec: mujoco.MjSpec, site_pos_overrides: dict[str, tuple[float, float, float]]) -> None:
+    """Override the local ``pos`` of named sites on an already-composed spec.
+
+    Lets downstream consumers reposition specific attachment/wrap sites (e.g.
+    a project-specific pelvis-attachment convention) without forking the
+    whole chain XML just to shift a handful of coordinates. Fails loudly on
+    unknown names rather than silently no-op, so stale overrides surface as
+    an error instead of a silent divergence.
+
+    Args:
+        spec: A composed (uncompiled) MjSpec, as returned by build_spec().
+        site_pos_overrides: Mapping of site name to a new local (x, y, z) pos.
+
+    Raises:
+        KeyError: If any named site is not present in the spec.
+    """
+    missing = [name for name in site_pos_overrides if spec.site(name) is None]
+    if missing:
+        raise KeyError(f"site_pos_overrides: site(s) not found in composed spec: {sorted(missing)}")
+    for name, pos in site_pos_overrides.items():
+        spec.site(name).pos = pos
+
+
+def build_spec(
+    model_name: str,
+    site_pos_overrides: dict[str, tuple[float, float, float]] | None = None,
+) -> mujoco.MjSpec:
+    """Build and return the composed, uncompiled MjSpec for a registered model.
+
+    Args:
+        model_name: Key into MODEL_REGISTRY (e.g. "myotorso_arms").
+        site_pos_overrides: Optional mapping of site name to a new local
+            (x, y, z) pos, applied after composition. Lets a downstream
+            consumer adjust a handful of attachment sites (e.g. pelvis
+            positioning for a project-specific skeleton) without needing a
+            forked copy of the underlying chain XML.
+
+    Returns:
+        The composed MjSpec, ready for further edits or spec.compile().
+    """
     try:
         registration = MODEL_REGISTRY[model_name]
     except KeyError as exc:
         available = ", ".join(sorted(MODEL_REGISTRY))
         raise ValueError(f"Unknown model selection: {model_name}. Available: {available}") from exc
-    return SPEC_BUILDERS[registration.build_strategy](registration)
+    spec = SPEC_BUILDERS[registration.build_strategy](registration)
+    if site_pos_overrides:
+        apply_site_pos_overrides(spec, site_pos_overrides)
+    return spec
 
 
 def build_model(model_name: str) -> mujoco.MjModel:

--- a/myo_sim/build/hand.py
+++ b/myo_sim/build/hand.py
@@ -76,6 +76,24 @@ RIGHT_HAND_REMOVED_JOINTS = frozenset(
     }
 )
 
+# Phantom/scaffold bodies that use the "tiny mass (1g) + huge [1,1,1] kg*m^2
+# inertia" idiom -- a deliberate MuJoCo trick that makes a body's absurd
+# rotational inertia harmless as long as the body's own joints fully
+# constrain its configuration (it never actually rotates freely under real
+# dynamics). Each of these bodies' only joints are in
+# RIGHT_HAND_REMOVED_JOINTS, so prune_arm_spec_to_hand() leaves them
+# jointless -- welded fixed to their parent. Once jointless, MuJoCo fuses a
+# fixed body's inertia into its parent's composite inertia at compile time,
+# turning the idiom's [1,1,1] into a real (and wildly wrong) contribution to
+# the mass matrix instead of a harmless joint-local value. See
+# https://github.com/MyoHub/myo_sim/issues/128.
+PHANTOM_SCAFFOLD_BODIES = frozenset({"clavphant", "scapphant", "humphant", "humphant1"})
+
+# Physically sane inertia floor substituted for PHANTOM_SCAFFOLD_BODIES once
+# jointless, matching the legacy static-XML numerical-conditioning
+# convention (see myo_sim.build.compose.build_spec(inertia_floor=...)).
+PHANTOM_SCAFFOLD_INERTIA_FLOOR = 0.0001
+
 
 def add_side_suffix(name: str, side: str) -> str:
     suffix = f"_{side}"
@@ -156,6 +174,29 @@ def bake_hand_preview_pose(spec: object, side: str) -> None:
     bake_current_body_poses(spec, model, data)
 
 
+def fix_up_welded_phantom_inertia(spec: object, side: str) -> None:
+    """Replace idiom-style inertia on phantom bodies left jointless by pruning.
+
+    PHANTOM_SCAFFOLD_BODIES rely on their own joints to make a nonphysical
+    [1,1,1] kg*m^2 inertia harmless. If pruning removed every joint on one
+    of these bodies (see RIGHT_HAND_REMOVED_JOINTS), it is now welded fixed
+    to its parent and that inertia would otherwise be fused directly into
+    the parent's composite inertia at compile time. Replace it with
+    PHANTOM_SCAFFOLD_INERTIA_FLOOR (matching the legacy numerical-
+    conditioning convention) on any such now-jointless body. Bodies that
+    still have a joint of their own (e.g. an unpruned full-arm spec) are
+    left untouched, since the idiom is safe there.
+
+    Args:
+        spec: A composed MjSpec being pruned, mutated in place.
+        side: "r" or "l" -- resolves each base name to its sided body name.
+    """
+    for base_name in PHANTOM_SCAFFOLD_BODIES:
+        body = spec.body(add_side_suffix(base_name, side))
+        if body is not None and len(body.joints) == 0:
+            body.inertia = [PHANTOM_SCAFFOLD_INERTIA_FLOOR] * 3
+
+
 def prune_arm_spec_to_hand(spec: object, side: str) -> None:
     """Remove proximal arm dynamics from an arm spec, leaving wrist/hand controls."""
     removed_joints = {side_name(name, side) for name in RIGHT_HAND_REMOVED_JOINTS}
@@ -190,5 +231,8 @@ def prune_arm_spec_to_hand(spec: object, side: str) -> None:
         joint = spec.joint(joint_name)
         if joint is not None:
             spec.delete(joint)
+
+    fix_up_welded_phantom_inertia(spec, side)
+
     for joint in spec.joints:
         joint.name = add_side_suffix(joint.name, side)

--- a/myo_sim/models/arm/assets/myoarm_r_chain.xml
+++ b/myo_sim/models/arm/assets/myoarm_r_chain.xml
@@ -88,7 +88,7 @@
                                 <geom name="humerus_r" mesh="humerus_r" type="mesh"/>
                                 <geom name="humerus_coll_r" type="capsule" class="myoarm_coll" size="0.042 0.140" pos="0 -.13 0" euler="1.57079632679 0 0"/>
                                 <geom name="Elbow_PT_ECRL_wrap" type="sphere" size="0.027" pos="-0.005 -0.3 0.005" class="myoarm_wrap"/>
-                                <geom name="Elbow_PT_FCU_wrap" type="sphere" size="0.015" pos="-0.005 -0.29 -0.053" class="myoarm_wrap"/>
+                                <geom name="Elbow_PT_FCU_wrap" type="sphere" size="0.015" pos="-0.005 -0.29 -0.033" class="myoarm_wrap"/>
                                 <site name="Elbow_PT_ECRL_site_ECRL_side_r" pos="0.03 -0.2872 0.04"/>
                                 <site name="Elbow_PT_FCU_site_FCU_side_r" pos="0.03 -0.2872 -0.04"/>
 
@@ -384,8 +384,8 @@
                                             <geom name="WristFlexor_wrap" pos="0 -0.01 -0.004" quat="0.807649 -0.0333177 0.588355 0.0207694" class="myoarm_wrap" size="0.007 0.02" type="cylinder"/>
                                             <geom name="ExtensorEllipse_ellipsoid_wrap" pos="-0.00145969 -0.0120017 -0.00892632" quat="0.977473 -0.106567 0.15459 0.0963907" class="myoarm_wrap" size="0.0237409"/>
                                             <!-- <geom name="PL_ellipsoid_wrap" pos="0.0170362 -0.0128706 0.0101738" quat="0.998158 -0.0141897 0.050277 0.0308429" class="myoarm_wrap" size="0.0272385"/> -->
-                                            <geom name="FDS_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="0.0012 -0.0057 0.0123" euler="0.00837758 1.48 -0.0171042" class="myoarm_wrap"/>
-                                            <geom name="FDP_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="-0.0022 -0.0069 0.0182" euler="-1.46747 1.37 0.121824" class="myoarm_wrap"/>
+                                            <geom name="FDS_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="0.0012 -0.0057 -0.0003" euler="0.00837758 1.48 -0.0171042" class="myoarm_wrap"/>
+                                            <geom name="FDP_ellipsoid_wrap" type="cylinder" size="0.013 0.025" pos="-0.0022 -0.0069 0.0032" euler="-1.46747 1.37 0.121824" class="myoarm_wrap"/>
                                             <geom name="EDM_ellipsoid_wrap" type="cylinder" size="0.014 0.018" pos="-0.0167 -0.0022 0.0048" euler="2.9627 1.73 0.117984" class="myoarm_wrap"/>
                                             <geom name="FPL_ellipsoid_wrap" type="sphere" size="0.015" pos="0.02 -0.025 -0.0033" class="myoarm_wrap"/>
                                             <geom name="ECRL_torus_wrap" pos="0.0222 -0.0096 0.0208" quat="0.637339 0.675155 -0.168467 0.331034" class="myoarm_wrap" size="0.008"/>
@@ -395,7 +395,7 @@
                                             <geom name="EDCL_torus_wrap" pos="-0.0128 -0.0133 0.0148" quat="0.386237 0.907673 0.159784 0.037683" class="myoarm_wrap" size="0.004"/>
                                             <geom name="EDCR_torus_wrap" pos="-0.0098 -0.0137 0.0166" quat="0.516906 0.814718 -0.18962 0.1819" class="myoarm_wrap" size="0.003"/>
                                             <geom name="EDCM_torus_wrap" pos="-0.0007 -0.0117 0.0191" quat="0.516192 0.831214 -0.100219 0.180516" class="myoarm_wrap" size="0.0035"/>
-                                            <geom name="EDCI_torus_wrap" pos="0.009 -0.0149 0.0215" quat="0.660055 0.749868 0.0267535 0.0361877" class="myoarm_wrap" size="0.0035"/>
+                                            <geom name="EDCI_torus_wrap" pos="0.009 -0.0149 0.0211" quat="0.660055 0.749868 0.0267535 0.0361877" class="myoarm_wrap" size="0.0035"/>
                                             <site name="ExtensorEllipse_ellipsoid_site_EIP_side_r" pos="-0.0195105 -0.00430577 0.0636576"/>
                                             <site name="PL_ellipsoid_site_PL_side_r" pos="-0.0286005 -0.023546 -0.0168168"/>
 
@@ -490,7 +490,7 @@
                                                             <joint axis="-0.084295 -0.203488 0.975442" name="mp_flexion_r" pos="0 0 0" range="-0.785398 0.698132"/>
                                                             <geom name="proximal_thumb_coll_r" class="myohand_coll" size="0.0085" fromto="0 0 0 0.014 -0.0259 -0.0101"/>
                                                             <geom mesh="thumbprox_r" name="thumbprox" type="mesh"/>
-                                                            <geom name="IPthumb_wrap" type="cylinder" size="0.00450000 0.005" pos="0.0121 -0.0232 -0.0096" euler="0.30473449 0.01291544 0.08796459" class="myoarm_wrap"/>
+                                                            <geom name="IPthumb_wrap" type="cylinder" size="0.00450000 0.005" pos="0.0121 -0.0302 -0.0096" euler="0.30473449 0.01291544 0.08796459" class="myoarm_wrap"/>
                                                             <inertial pos="0.0096 -0.0163 -0.0063" mass="0.0079" fullinertia="2.6e-07 7.1e-07 2.9e-07 1e-07 4e-08 -6e-08"/>
                                                             <site name="EPL-P10_r" pos="0.0115 -0.0036 0.0016"/>
                                                             <site name="EPL-P11_r" pos="0.0192 -0.0265 -0.0104"/>
@@ -527,7 +527,7 @@
                                                 <body name="secondmc_r" pos="0.014685 -0.03762 0.005032">
                                                     <geom name="2mcskin_coll_r" class="myohand_coll" size="0.010 0.028" euler="1.42 0.15 -.1"/>
                                                     <geom mesh="2mc_r" name="2mc_r" type="mesh"/>
-                                                    <geom name="2ndmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="0.0058 -0.0314 0.0007" euler="0.84927721 -1.33552594 1.33814394" class="myoarm_wrap"/>
+                                                    <geom name="2ndmcp_ellipsoid_wrap" type="cylinder" size="0.0065 0.005" pos="0.0058 -0.0294 0.0007" euler="0.84927721 -1.33552594 1.33814394" class="myoarm_wrap"/>
                                                     <inertial pos="0 0 0" mass="0.02" fullinertia="0.0001 0.0001 0.0001 0 0 0"/>
                                                     <site name="ECRL-P4_r" pos="0.0025 0.0164 0.0008"/>
                                                     <site name="FCR-P3_r" pos="-0.0034 0.0192 -0.0092"/>


### PR DESCRIPTION
## Summary
- Adds an optional `site_pos_overrides: dict[str, tuple[float,float,float]] | None` parameter to `myo_sim.build.compose.build_spec()`, threaded through the public `myo_sim.load_spec()`.
- After composition, named sites have their local `pos` overridden. Unknown site names raise `KeyError` (fail loud, not silent no-op).
- No override = byte-for-byte identical behavior to today (verified `nbody` match on `myotorso_arms` with/without `site_pos_overrides=None`).

## Motivation
Downstream consumers (myosuite) occasionally need a composed model with a handful of attachment/wrap sites repositioned for a project-specific skeleton convention — e.g. myosuite's soccer environment currently ships a 711-line hand-forked copy of `torso/assets/myotorso_chain.xml` whose only real difference from myo_sim's own chain is ~113 sites shifted by a uniform pelvis-attachment offset (plus a handful of additional hand-tuned sites). That's a lot of duplicated/driftable XML to maintain just to reposition a few coordinates.

With this change, a consumer can do:
```python
spec = myo_sim.load_spec("myotorso", site_pos_overrides={"Ps_L1_VB_Ps_L1_VB-P2_r": (-0.0238, -0.057, 0.0759), ...})
```
instead of forking the whole chain file.

## Test plan
- [x] `python -m pytest tests/` — 109 passed, 1 skipped (unchanged from base)
- [x] Backward compat: `build_spec("myotorso_arms")` produces identical `nbody` with and without `site_pos_overrides=None`
- [x] Override applies correctly: overridden site's `.pos` reflects the new value, spec still compiles
- [x] Unknown site name raises `KeyError` listing the missing name(s), rather than silently no-op
- [x] `pre-commit run --files myo_sim/build/compose.py myo_sim/__init__.py` clean (ruff + ruff-format)