### PR TITLE
Mirror the left knee's translation2 and rotation3 polynomials

### DIFF
--- a/myo_sim/models/leg/assets/myolegs_assets.xml
+++ b/myo_sim/models/leg/assets/myolegs_assets.xml
@@ -71,10 +71,10 @@
         <joint joint1="knee_angle_beta_rotation1_r" joint2="knee_angle_r" name="knee_angle_beta_rotation1_constraint_r" polycoef="0.010506 0.0247615 -1.31647 0.716337 -0.138302" solimp="0.9999 0.9999 0.001 0.5 2"/>
         <!-- <joint joint1="subtalar_angle_r" name="subtalar_angle_r_constraint" polycoef="0 0 0 0 0"/> -->
         <!-- <joint joint1="mtp_angle_r" name="mtp_angle_r_constraint" polycoef="0 0 0 0 0"/> -->
-        <joint joint1="knee_angle_translation2_l" joint2="knee_angle_l" name="knee_angle_translation2_constraint_l" polycoef="-7.69254e-11 -0.00587971 0.00125622 2.61846e-06 -6.24355e-07" solimp="0.9999 0.9999 0.001 0.5 2"/>
+        <joint joint1="knee_angle_translation2_l" joint2="knee_angle_l" name="knee_angle_translation2_constraint_l" polycoef="7.69254e-11 0.00587971 -0.00125622 -2.61846e-06 6.24355e-07" solimp="0.9999 0.9999 0.001 0.5 2"/>
         <joint joint1="knee_angle_translation1_l" joint2="knee_angle_l" name="knee_angle_translation1_constraint_l" polycoef="9.53733e-08 0.00312879 -0.00230804 0.000561561 5.68366e-07" solimp="0.9999 0.9999 0.001 0.5 2"/>
         <joint joint1="knee_angle_rotation2_l" joint2="knee_angle_l" name="knee_angle_rotation2_constraint_l" polycoef="-1.47325e-08 0.0791 -0.0328478 -0.0252183 0.0108321" solimp="0.9999 0.9999 0.001 0.5 2"/>
-        <joint joint1="knee_angle_rotation3_l" joint2="knee_angle_l" name="knee_angle_rotation3_constraint_l" polycoef="-1.08939e-08 -0.369499 0.169478 -0.0251643 -3.50498e-07" solimp="0.9999 0.9999 0.001 0.5 2"/>
+        <joint joint1="knee_angle_rotation3_l" joint2="knee_angle_l" name="knee_angle_rotation3_constraint_l" polycoef="1.08939e-08 0.369499 -0.169478 0.0251643 3.50498e-07" solimp="0.9999 0.9999 0.001 0.5 2"/>
         <joint joint1="knee_angle_beta_translation2_l" joint2="knee_angle_l" name="knee_angle_beta_translation2_constraint_l" polycoef="-0.0108281 -0.0487847 0.00927644 0.0131673 -0.00349673" solimp="0.9999 0.9999 0.001 0.5 2"/>
         <joint joint1="knee_angle_beta_translation1_l" joint2="knee_angle_l" name="knee_angle_beta_translation1_constraint_l" polycoef="0.0524192 -0.0150188 -0.0340522 0.0133393 -0.000879151" solimp="0.9999 0.9999 0.001 0.5 2"/>
         <joint joint1="knee_angle_beta_rotation1_l" joint2="knee_angle_l" name="knee_angle_beta_rotation1_constraint_l" polycoef="0.010506 0.0247615 -1.31647 0.716337 -0.138302" solimp="0.9999 0.9999 0.001 0.5 2"/>

--- a/tests/test_leg_muscle_symmetry.py
+++ b/tests/test_leg_muscle_symmetry.py
@@ -37,9 +37,6 @@ def test_discovered_leg_muscle_pairs_have_symmetric_curves(leg_model_context, di
     failures = []
     checked_pairs = []
     for pair in discovered_leg_pairs:
-        # The current non-abdomen leg model has known left/right knee-angle curve differences.
-        if pair.right_joint == "knee_angle_r" or pair.left_joint == "knee_angle_l":
-            continue
         checked_pairs.append(pair)
         summary = compare_muscle_pair(model, data, eq_map, pair)
         if not summary["ok"]:


### PR DESCRIPTION
Two coupled coordinates in the left knee of myolegs have their polynomial negated, and I
thought it should match the right leg's. Every other coupling in the knee has the same
polynomial on both sides. These two are negated instead. I measured it by bending both
knees by the same amount and comparing the left shinbone with the mirror of the right. At
120 degrees of flexion I got the left 13.6 mm out of position and 30 degrees out of
orientation and instead further down the leg at 90 degrees the heel sits 6 cm from its
mirror. When I made these two coefficients match the right leg, I get zero at every angle
I tried. Your own test already sees this. tests/test_leg_muscle_symmetry.py skips the knee
pairs, with a comment about known left/right knee-angle differences. I removed the skip:
without the fix it fails on those pairs, with the fix it passes. I saw even that the other
five couplings in the knee contribute exactly zero, and everything else in the model at
most half a millimetre. myolegs26 gets all fourteen of its couplings right.

I read in the README that some of the known limitations in the leg are problems related
to the knee dependent joint constraints. I have no way to tell whether this is related,
but it seems useful to report it.
